### PR TITLE
Tell Jekyll not to expose the src directory.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+exclude: [src, testing]


### PR DESCRIPTION
cc @gspencergoog 

Right now Jekyll isn't building the assets site because the src/ directory now has a symlink that points somewhere outside the repo. This is intended to make it ignore the src/ directory.