### PR TITLE
Fix deprecated UTF8 call

### DIFF
--- a/src/generate.dart
+++ b/src/generate.dart
@@ -108,10 +108,10 @@ class DiagramGenerator {
   }) async {
     final Process process = await processStarter(flutterCommand, args, workingDirectory: projectDir);
     final List<String> lines = <String>[];
-    process.stdout.transform(UTF8.decoder).transform(const LineSplitter()).listen((String data) {
+    process.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((String data) {
       lines.add(data);
     });
-    process.stderr.transform(UTF8.decoder).transform(const LineSplitter()).listen((String data) {
+    process.stderr.transform(utf8.decoder).transform(const LineSplitter()).listen((String data) {
       lines.add(data);
     });
     final DateTime startWait = new DateTime.now();


### PR DESCRIPTION
This PR resolves the analyzer failure on Travis by replacing calls to the deprecated `UTF8` with `utf8`.