### PR TITLE
Some tweaks to the CI testing and update packages.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,7 @@ task:
     BUILD_DIR: "/tmp/build"
     CIRRUS_WORKING_DIR: "$BUILD_DIR/assets-for-api-docs"
     FLUTTER_DIR: "$BUILD_DIR/flutter"
+    OS_NAME: "linux"
 
   git_fetch_script: git fetch origin
   setup_script: |
@@ -23,12 +24,12 @@ task:
       env:
         SHARD: analyze
       test_script:
-        - ./bin/testing.sh analyze
+        - ./bin/testing.sh
     - name: tests-linux
       env:
         SHARD: tests
       test_script:
-        - ./bin/testing.sh test
+        - ./bin/testing.sh
       container:
         cpu: 4
         memory: 8G

--- a/bin/testing.sh
+++ b/bin/testing.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
 set -e
 
-if [[ -n '$CIRRUS_CI' ]]; then
-  export PATH="$FLUTTER_DIR/bin:$FLUTTER_DIR/bin/cache/dart-sdk/bin:$PATH"
-fi
-
 # So that users can run this script from anywhere and it will work as expected.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
-if [[ "$1" == "analyze" ]]; then
+if [[ -n "$CIRRUS_CI" ]]; then
+  echo "Updating PATH."
+  export PATH="$FLUTTER_DIR/bin:$FLUTTER_DIR/bin/cache/dart-sdk/bin:$PATH"
+else
+  echo "Updating packages."
+  "$SCRIPT_DIR/update_packages.sh"
+fi
+
+# Default to the first arg if SHARD isn't set, and to "test" if neither are set.
+SHARD="${SHARD:-${1:-test}}"
+
+if [[ "$SHARD" == "analyze" ]]; then
   echo "Analyzing Dart files."
   for dir in bin packages utils; do
     (cd "$REPO_DIR/$dir" && flutter analyze)
   done
-elif [[ "$1" == "test" ]]; then
+elif [[ "$SHARD" == "test" ]]; then
   echo "Running tests."
   (cd "$REPO_DIR/bin" && pub run test/generate_test.dart)
   (cd "$REPO_DIR/packages/diagram_capture" && flutter test)

--- a/bin/update_packages.sh
+++ b/bin/update_packages.sh
@@ -14,3 +14,7 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 for dir in "$REPO_DIR/bin" "$REPO_DIR/packages/"* "$REPO_DIR/utils/"*; do
   (cd "$dir" && flutter packages get)
 done
+
+# Also update packages just with pub in bin, since there are non-flutter packages
+# there.
+(cd "$REPO_DIR/bin" && pub get)


### PR DESCRIPTION
This just makes some small tweaks to the CI testing and update packages script.

The testing script can be more easily run locally, and the update_packages script runs `pub get` in bin as well, since `flutter packages get` wasn't sufficient.