### PR TITLE
Have Cirrus use master instead of dev for precommit checks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ task:
   git_fetch_script: git fetch origin
   setup_script: |
     # Clone Flutter repo, pinned to the dev branch.
-    git clone --branch dev https://github.com/flutter/flutter.git "$FLUTTER_DIR"
+    git clone --branch master https://github.com/flutter/flutter.git "$FLUTTER_DIR"
     
     echo "Synced to revision: $(cd "$FLUTTER_DIR" && git rev-parse HEAD)"
 


### PR DESCRIPTION
This moves Cirrus over to use the master branch as the one to sync for doing the CI checks, which avoids problems when trying to add diagrams that use a new Flutter API. It does mean that a broken master branch can also break a PR here, but hopefully that is fairly rare (and this repo is pretty low traffic, so not a huge cost in any case).