### PR TITLE
Pin analyzer version to avoid bad 1.6.0

### DIFF
--- a/bin/pubspec.yaml
+++ b/bin/pubspec.yaml
@@ -8,9 +8,7 @@ dependencies:
   process_runner: ">=4.0.0 <5.0.0"
 
 dev_dependencies:
-  # Pinning analyzer because of a temporary incompatibility with test package in
-  # released version of 1.6.0.
-  # TODO(gspencergoog): unpin this version once incompatibility is resolved.
+  # TODO(gspencergoog): unpin this version once https://github.com/dart-lang/sdk/issues/46136 is fixed.
   analyzer: ">=1.4.0 <1.6.0"
   test: ^1.16.8
 

--- a/utils/sampler/pubspec.yaml
+++ b/utils/sampler/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  # TODO(gspencergoog): unpin this version once https://github.com/dart-lang/sdk/issues/46136 is fixed.
+  analyzer: ">=1.4.0 <1.6.0"
   args: ^2.0.0
   crypto: ^3.0.1
   file: ^6.1.0


### PR DESCRIPTION
This pins the analyzer to not allow 1.6.0, since the analyzer has a bad version that won't compile.

For reference: https://github.com/dart-lang/sdk/issues/46136