### PR TITLE
Make snippets conform to the old snippets tool by formatting output

### DIFF
--- a/packages/snippets/lib/util.dart
+++ b/packages/snippets/lib/util.dart
@@ -160,7 +160,8 @@ String interpolateTemplate(
       ...contents,
       if (addSectionMarkers) sectionArrows(name, start: false),
     ].join('\n');
-    return result.isEmpty ? result : '$result\n';
+    final RegExp wrappingNewlines = RegExp(r'^\n*(.*)\n*$', dotAll: true);
+    return result.replaceAllMapped(wrappingNewlines, (Match match) => match.group(1)!);
   }
 
   return '${addCopyright ? '{{copyright}}\n\n' : ''}$template'

--- a/packages/snippets/test/snippets_test.dart
+++ b/packages/snippets/test/snippets_test.dart
@@ -120,9 +120,9 @@ void main() {
       expect(html, isNot(contains('sample_channel=stable')));
       expect(
           html,
-          contains('&#47;&#47; A description of the snippet.\n'
-              '&#47;&#47;\n'
-              '&#47;&#47; On several lines.\n'));
+          contains('A description of the snippet.\n'
+              '\n'
+              'On several lines.{@inject-html}</div>'));
       expect(html, contains('void main() {'));
 
       final String outputContents = outputFile.readAsStringSync();
@@ -172,7 +172,7 @@ void main() {
           html,
           contains(
               '<div class="snippet-description">{@end-inject-html}A description of the snippet.\n\n'
-              'On several lines.\n{@inject-html}</div>\n'));
+              'On several lines.{@inject-html}</div>\n'));
       expect(html, contains('main() {'));
     });
 
@@ -259,7 +259,7 @@ void main() {
       expect(json['id'], equals('MyElement.0'));
       expect(json['channel'], equals('stable'));
       expect(json['file'], equals('snippet_out.dart'));
-      expect(json['description'], equals('A description of the snippet.\n\nOn several lines.\n'));
+      expect(json['description'], equals('A description of the snippet.\n\nOn several lines.'));
       expect(json['sourcePath'], equals('packages/flutter/lib/src/widgets/foo.dart'));
     });
   });


### PR DESCRIPTION
## Description

This makes the snippets tool output conform more closely with the output from the original one in the Flutter repo.  This PR changes the output so that it is formatter with the Dart formatter, and so that it only outputs samples if they are `dartpad` or `sample` samples, not just snippets.

## Tests
 - Updated output tests to take into account the new format.