### PR TITLE
Make linked samples parseable

### DIFF
--- a/.run/Extract.run.xml
+++ b/.run/Extract.run.xml
@@ -6,8 +6,6 @@
     </option>
     <option name="filePath" value="$PROJECT_DIR$/packages/snippets/bin/extract.dart" />
     <option name="workingDirectory" value="$PROJECT_DIR$/../flutter" />
-    <method v="2">
-      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_Remove API" />
-    </method>
+    <method v="2" />
   </configuration>
 </component>

--- a/.run/Snippets.run.xml
+++ b/.run/Snippets.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Snippets" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="arguments" value="--type dartpad --template=stateful_widget_scaffold_center --input=sample.input --package=package --library=library --element=element --serial=0 --output=/tmp/sample.out" />
+    <option name="envs">
+      <entry key="FLUTTER_ROOT" value="$PROJECT_DIR$/../flutter" />
+    </option>
+    <option name="filePath" value="$PROJECT_DIR$/packages/snippets/bin/snippets.dart" />
+    <option name="workingDirectory" value="$PROJECT_DIR$/../flutter" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/snippets/CHANGELOG.md
+++ b/packages/snippets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.1
 
+* Enable parsing of linked samples, add section markers to extracted samples.
+
+## 0.2.1
+
 * Format the sample output, so that it matches the existing tool in the Flutter repo.
 
 ## 0.2.0

--- a/packages/snippets/CHANGELOG.md
+++ b/packages/snippets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for `snippets`
 
-## 0.2.1
+## 0.2.2
 
 * Enable parsing of linked samples, add section markers to extracted samples.
 

--- a/packages/snippets/bin/snippets.dart
+++ b/packages/snippets/bin/snippets.dart
@@ -161,7 +161,7 @@ void main(List<String> argList) {
     _kFormatOutputOption,
     defaultsTo: true,
     negatable: true,
-    help: 'Prints help documentation for this command',
+    help: 'Applies the Dart formatter to the published/extracted sample code.',
   );
   parser.addFlag(
     _kHelpOption,

--- a/packages/snippets/bin/snippets.dart
+++ b/packages/snippets/bin/snippets.dart
@@ -67,7 +67,6 @@ String getChannelName({
       ? '<unknown>'
       : gitBranchMatch.namedGroup('branch')!.split('...').first;
 }
-
 const List<String> sampleTypes = <String>[
   'snippet',
   'sample',
@@ -96,6 +95,7 @@ String getChannelNameWithRetries() {
 void main(List<String> argList) {
   const Platform platform = LocalPlatform();
   final Map<String, String> environment = platform.environment;
+
   final ArgParser parser = ArgParser();
 
   parser.addOption(
@@ -240,7 +240,7 @@ void main(List<String> argList) {
   final int? sourceLine =
       environment['SOURCE_LINE'] != null ? int.tryParse(environment['SOURCE_LINE']!) : null;
   final String sourcePath = environment['SOURCE_PATH'] ?? 'unknown.dart';
-  final SnippetDartdocParser sampleParser = SnippetDartdocParser();
+  final SnippetDartdocParser sampleParser = SnippetDartdocParser(filesystem);
   final SourceElement element = sampleParser.parseFromDartdocToolFile(
     input,
     startLine: sourceLine,

--- a/packages/snippets/bin/snippets.dart
+++ b/packages/snippets/bin/snippets.dart
@@ -12,14 +12,15 @@ import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 import 'package:snippets/snippets.dart';
 
-const String _kSerialOption = 'serial';
 const String _kElementOption = 'element';
+const String _kFormatOutputOption = 'format-output';
 const String _kHelpOption = 'help';
 const String _kInputOption = 'input';
 const String _kLibraryOption = 'library';
-const String _kOutputOption = 'output';
 const String _kOutputDirectoryOption = 'output-directory';
+const String _kOutputOption = 'output';
 const String _kPackageOption = 'package';
+const String _kSerialOption = 'serial';
 const String _kTemplateOption = 'template';
 const String _kTypeOption = 'type';
 
@@ -157,6 +158,12 @@ void main(List<String> argList) {
     help: 'A unique serial number for this snippet tool invocation.',
   );
   parser.addFlag(
+    _kFormatOutputOption,
+    defaultsTo: true,
+    negatable: true,
+    help: 'Prints help documentation for this command',
+  );
+  parser.addFlag(
     _kHelpOption,
     defaultsTo: false,
     negatable: false,
@@ -197,6 +204,7 @@ void main(List<String> argList) {
     template = templateArg.replaceAll(RegExp(r'.tmpl$'), '');
   }
 
+  final bool formatOutput = args[_kFormatOutputOption]! as bool;
   final String packageName = args[_kPackageOption] as String? ?? '';
   final String libraryName = args[_kLibraryOption] as String? ?? '';
   final String elementName = args[_kElementOption] as String? ?? '';
@@ -264,6 +272,7 @@ void main(List<String> argList) {
     generator.generateCode(
       sample,
       output: output,
+      formatOutput: formatOutput,
     );
     print(generator.generateHtml(sample));
   }

--- a/packages/snippets/bin/snippets.dart
+++ b/packages/snippets/bin/snippets.dart
@@ -96,7 +96,6 @@ String getChannelNameWithRetries() {
 void main(List<String> argList) {
   const Platform platform = LocalPlatform();
   final Map<String, String> environment = platform.environment;
-
   final ArgParser parser = ArgParser();
 
   parser.addOption(

--- a/packages/snippets/example/bin/main.dart
+++ b/packages/snippets/example/bin/main.dart
@@ -25,7 +25,7 @@ void main(List<String> argList) {
     exit(-1);
   }
 
-  final SnippetDartdocParser snippetParser = SnippetDartdocParser();
+  final SnippetDartdocParser snippetParser = SnippetDartdocParser(filesystem);
 
   final File file = filesystem.file(args['file']! as String);
   final List<SourceElement> elements = getFileElements(file).toList();

--- a/packages/snippets/lib/data_types.dart
+++ b/packages/snippets/lib/data_types.dart
@@ -103,7 +103,7 @@ abstract class CodeSample {
           if (!doneStrippingHeaders && RegExp(r'^\s*(\/\/.*)?$').hasMatch(line)) {
             continue;
           }
-          // Stop at the first line that isn't stripped.
+          // Stop skipping lines after the first line that isn't stripped.
           doneStrippingHeaders = true;
           stripped.add(line);
         }
@@ -113,7 +113,12 @@ abstract class CodeSample {
           file: _lineProto.file?.absolute.path,
         );
       }
-      _sourceFileContents = stripped.join('\n');
+      // Remove any section markers
+      final RegExp sectionMarkerRegExp = RegExp(
+        r'(\/\/\*\*+\n)?\/\/\* [▼▲]+.*$(\n\/\/\*\*+)?\n\n?',
+        multiLine: true,
+      );
+      _sourceFileContents = stripped.join('\n').replaceAll(sectionMarkerRegExp, '');
     }
     return _sourceFileContents ?? '';
   }
@@ -280,7 +285,8 @@ class DartpadSample extends ApplicationSample {
     required int index,
     required SourceLine lineProto,
   })  : assert(args.isNotEmpty),
-        super.fromFile(input: input, args: args, sourceFile: sourceFile, index: index, lineProto: lineProto);
+        super.fromFile(
+            input: input, args: args, sourceFile: sourceFile, index: index, lineProto: lineProto);
 
   @override
   String get type => 'dartpad';

--- a/packages/snippets/lib/data_types.dart
+++ b/packages/snippets/lib/data_types.dart
@@ -4,7 +4,8 @@
 
 import 'package:args/args.dart';
 import 'package:file/file.dart';
-import 'package:snippets/snippets.dart';
+
+import 'util.dart';
 
 /// A class to represent a line of input code, with associated line number, file
 /// and element name.

--- a/packages/snippets/lib/flutter_sample_editor.dart
+++ b/packages/snippets/lib/flutter_sample_editor.dart
@@ -79,7 +79,7 @@ class FlutterSampleLiberator {
       throw SnippetException(
           'Unable to find original location for sample ${sample.index} on ${sample.element} in ${element.file}');
     }
-    final SnippetDartdocParser parser = SnippetDartdocParser();
+    final SnippetDartdocParser parser = SnippetDartdocParser(filesystem);
     final SourceElement matchingElement = matchingElements.first;
     parser.parseComment(matchingElement);
     final List<CodeSample> foundBlocks = matchingElement.samples.where((CodeSample foundSample) {
@@ -342,14 +342,14 @@ include: ${flutterRoot.absolute.path}/analysis_options.yaml
     String frameworkContents = await frameworkFile.readAsString();
 
     final SnippetGenerator generator = SnippetGenerator();
-    generator.parseInput(matchingSample);
+    generator.parseInput(matchingSample); // Just to get the description.
 
     // Create a substitute example that only contains a reference to the
     // output file, and the description.
     final String linkPath = path.relative(mainDart.path, from: flutterRoot.absolute.path);
     final String replacement = _buildSampleReplacement(<String, List<String>>{
       'description': matchingSample.description.split('\n'),
-      'sampleLink': <String>['[See code in $linkPath]'],
+      'sampleLink': <String>['** See code in $linkPath **'],
     }, <String>['description', 'sampleLink'], rangesAndIndents['firstIndent']!);
     // Rewrite the original framework file.
     frameworkContents = frameworkContents.replaceRange(

--- a/packages/snippets/lib/snippet_generator.dart
+++ b/packages/snippets/lib/snippet_generator.dart
@@ -325,6 +325,7 @@ class SnippetGenerator {
     File? output,
     String? copyright,
     String? description,
+    bool formatOutput = true,
     bool addSectionMarkers = false,
     bool includeAssumptions = false,
   }) {
@@ -369,14 +370,16 @@ class SnippetGenerator {
           app = sample.sourceFileContents;
         }
         sample.output = app;
-        final DartFormatter formatter = DartFormatter(pageWidth: 80, fixes: StyleFix.all);
-        try {
-          sample.output = formatter.format(sample.output);
-        } on FormatterException catch (exception) {
-          io.stderr.write('Code to format:\n${_addLineNumbers(sample.output)}\n');
-          errorExit('Unable to format sample code: $exception');
+        if (formatOutput) {
+          final DartFormatter formatter = DartFormatter(pageWidth: 80, fixes: StyleFix.all);
+          try {
+            sample.output = formatter.format(sample.output);
+          } on FormatterException catch (exception) {
+            io.stderr.write('Code to format:\n${_addLineNumbers(sample.output)}\n');
+            errorExit('Unable to format sample code: $exception');
+          }
+          sample.output = sortImports(sample.output);
         }
-        sample.output = sortImports(sample.output);
         if (output != null) {
           output.writeAsStringSync(sample.output);
 

--- a/packages/snippets/lib/snippet_generator.dart
+++ b/packages/snippets/lib/snippet_generator.dart
@@ -301,7 +301,8 @@ class SnippetGenerator {
     return sample.description.splitMapJoin(
       '\n',
       onMatch: (Match match) => match.group(0)!,
-      onNonMatch: (String nonmatch) => nonmatch.trimRight().isEmpty ? '//' : '// ${nonmatch.trimRight()}',
+      onNonMatch: (String nonmatch) =>
+          nonmatch.trimRight().isEmpty ? '//' : '// ${nonmatch.trimRight()}',
     );
   }
 
@@ -336,28 +337,37 @@ class SnippetGenerator {
     switch (sample.runtimeType) {
       case DartpadSample:
       case ApplicationSample:
-        final Directory templatesDir = configuration.templatesDirectory;
-        final String templateName = sample.template;
-        final File? templateFile = getTemplatePath(templateName, templatesDir: templatesDir);
-        if (templateFile == null) {
-          io.stderr.writeln('The template $templateName was not found in the templates '
-              'directory ${templatesDir.path}');
-          io.exit(1);
+        String app;
+        if (sample.sourceFile == null) {
+          final Directory templatesDir = configuration.templatesDirectory;
+          final String templateName = sample.template;
+          final File? templateFile = getTemplatePath(templateName, templatesDir: templatesDir);
+          if (templateFile == null) {
+            io.stderr.writeln('The template $templateName was not found in the templates '
+                'directory ${templatesDir.path}');
+            io.exit(1);
+          }
+          final String templateContents = _loadFileAsUtf8(templateFile);
+          final String templateRelativePath =
+              templateFile.absolute.path.contains(flutterRoot.absolute.path)
+                  ? path.relative(templateFile.absolute.path, from: flutterRoot.absolute.path)
+                  : templateFile.absolute.path;
+          final String templateHeader = '''
+// Template: $templateRelativePath
+//
+// Comment lines marked with "▼▼▼" and "▲▲▲" are used for authoring
+// of samples, and may be ignored if you are just exploring the sample.
+''';
+          app = interpolateTemplate(
+            snippetData,
+            addSectionMarkers ? '$templateHeader\n$templateContents' : templateContents,
+            sample.metadata,
+            addSectionMarkers: addSectionMarkers,
+            addCopyright: copyright != null,
+          );
+        } else {
+          app = sample.sourceFileContents;
         }
-        final String templateContents = _loadFileAsUtf8(templateFile);
-        final String templateRelativePath =
-            templateFile.absolute.path.contains(flutterRoot.absolute.path)
-                ? path.relative(templateFile.absolute.path, from: flutterRoot.absolute.path)
-                : templateFile.absolute.path;
-        final String app = interpolateTemplate(
-          snippetData,
-          addSectionMarkers
-              ? '/// Template: $templateRelativePath\n$templateContents'
-              : templateContents,
-          sample.metadata,
-          addSectionMarkers: addSectionMarkers,
-          addCopyright: copyright != null,
-        );
         sample.output = app;
         final DartFormatter formatter = DartFormatter(pageWidth: 80, fixes: StyleFix.all);
         try {
@@ -383,20 +393,25 @@ class SnippetGenerator {
         break;
       case SnippetSample:
         if (sample is SnippetSample) {
-          String templateContents;
-          if (includeAssumptions) {
-            templateContents =
-                '${headers.map<String>((SourceLine line) => line.text).join('\n')}\n{{#assumptions}}\n{{description}}\n{{code}}';
+          String app;
+          if (sample.sourceFile == null) {
+            String templateContents;
+            if (includeAssumptions) {
+              templateContents =
+                  '${headers.map<String>((SourceLine line) => line.text).join('\n')}\n{{#assumptions}}\n{{description}}\n{{code}}';
+            } else {
+              templateContents = '{{description}}\n{{code}}';
+            }
+            app = interpolateTemplate(
+              snippetData,
+              templateContents,
+              sample.metadata,
+              addSectionMarkers: addSectionMarkers,
+              addCopyright: copyright != null,
+            );
           } else {
-            templateContents = '{{description}}\n{{code}}';
+            app = sample.inputAsString;
           }
-          final String app = interpolateTemplate(
-            snippetData,
-            templateContents,
-            sample.metadata,
-            addSectionMarkers: addSectionMarkers,
-            addCopyright: copyright != null,
-          );
           sample.output = app;
         }
         break;

--- a/packages/snippets/lib/util.dart
+++ b/packages/snippets/lib/util.dart
@@ -155,10 +155,17 @@ String interpolateTemplate(
   bool addCopyright = false,
 }) {
   String wrapSectionMarker(Iterable<String> contents, {required String name}) {
+    if (contents.join('').trim().isEmpty) {
+      // Skip empty sections.
+      return '';
+    }
+    // We don't wrap some sections, because otherwise they generate invalid files.
+    const Set<String> skippedSections = <String>{'element', 'copyright'};
+    final bool addMarkers = addSectionMarkers && !skippedSections.contains(name);
     final String result = <String>[
-      if (addSectionMarkers) sectionArrows(name, start: true),
+      if (addMarkers) sectionArrows(name, start: true),
       ...contents,
-      if (addSectionMarkers) sectionArrows(name, start: false),
+      if (addMarkers) sectionArrows(name, start: false),
     ].join('\n');
     final RegExp wrappingNewlines = RegExp(r'^\n*(.*)\n*$', dotAll: true);
     return result.replaceAllMapped(wrappingNewlines, (Match match) => match.group(1)!);

--- a/packages/snippets/pubspec.yaml
+++ b/packages/snippets/pubspec.yaml
@@ -1,5 +1,5 @@
 name: snippets
-version: 0.2.1
+version: 0.2.2
 description: A package for parsing and manipulating code samples in Flutter repo dartdoc comments.
 homepage: https://github.com/flutter/flutter
 

--- a/packages/snippets/test/snippet_parser_test.dart
+++ b/packages/snippets/test/snippet_parser_test.dart
@@ -91,7 +91,7 @@ void main() {
       final Iterable<SourceElement> elements = getFileElements(inputFile,
           resourceProvider: FileSystemResourceProvider(memoryFileSystem));
       expect(elements, isNotEmpty);
-      final SnippetDartdocParser sampleParser = SnippetDartdocParser();
+      final SnippetDartdocParser sampleParser = SnippetDartdocParser(memoryFileSystem);
       sampleParser.parseFromComments(elements);
       sampleParser.parseAndAddAssumptions(elements, inputFile);
       expect(elements.length, equals(7));
@@ -114,7 +114,7 @@ void main() {
     });
     test('parses assumptions', () async {
       final File inputFile = _createSourceFile(tmpDir, memoryFileSystem);
-      final SnippetDartdocParser sampleParser = SnippetDartdocParser();
+      final SnippetDartdocParser sampleParser = SnippetDartdocParser(memoryFileSystem);
       final List<SourceLine> assumptions = sampleParser.parseAssumptions(inputFile);
       expect(assumptions.length, equals(1));
       expect(assumptions.first.text, equals('int integer = 3;'));

--- a/packages/snippets/test/snippet_parser_test.dart
+++ b/packages/snippets/test/snippet_parser_test.dart
@@ -33,6 +33,7 @@ void main() {
     late SnippetGenerator generator;
     late Directory tmpDir;
     late File template;
+    late Directory flutterRoot;
 
     void _writeSkeleton(String type) {
       switch (type) {
@@ -60,7 +61,7 @@ void main() {
       // Create a new filesystem.
       memoryFileSystem = MemoryFileSystem();
       tmpDir = memoryFileSystem.systemTempDirectory.createTempSync('flutter_snippets_test.');
-      final Directory flutterRoot =
+      flutterRoot =
           memoryFileSystem.directory(path.join(tmpDir.absolute.path, 'flutter'));
       configuration =
           FlutterRepoSnippetConfiguration(flutterRoot: flutterRoot, filesystem: memoryFileSystem);
@@ -87,7 +88,7 @@ void main() {
     });
 
     test('parses from comments', () async {
-      final File inputFile = _createSourceFile(tmpDir, memoryFileSystem);
+      final File inputFile = _createSnippetSourceFile(tmpDir, memoryFileSystem);
       final Iterable<SourceElement> elements = getFileElements(inputFile,
           resourceProvider: FileSystemResourceProvider(memoryFileSystem));
       expect(elements, isNotEmpty);
@@ -102,9 +103,9 @@ void main() {
         final String code = generator.generateCode(element.samples.first);
         expect(code, contains('// Description'));
         expect(
-            code, contains(RegExp('^void ${element.name}Sample\\(\\) \\{.*\$', multiLine: true)));
+            code, contains(RegExp('''^String elementName = '${element.elementName}';\$''', multiLine: true)));
         final String html = generator.generateHtml(element.samples.first);
-        expect(html, contains(RegExp(r'^<pre>void .*Sample\(\) \{.*$', multiLine: true)));
+        expect(html, contains(RegExp('''^<pre>String elementName = &#39;${element.elementName}&#39;;.*\$''', multiLine: true)));
         expect(
             html,
             contains(
@@ -112,8 +113,50 @@ void main() {
       }
       expect(sampleCount, equals(8));
     });
+    test('parses dartpad samples from comments', () async {
+      final File inputFile = _createDartpadSourceFile(tmpDir, memoryFileSystem, flutterRoot);
+      final Iterable<SourceElement> elements = getFileElements(inputFile,
+          resourceProvider: FileSystemResourceProvider(memoryFileSystem));
+      expect(elements, isNotEmpty);
+      final SnippetDartdocParser sampleParser = SnippetDartdocParser(memoryFileSystem);
+      sampleParser.parseFromComments(elements);
+      expect(elements.length, equals(1));
+      int sampleCount = 0;
+      for (final SourceElement element in elements) {
+        expect(element.samples.length, greaterThanOrEqualTo(1));
+        sampleCount += element.samples.length;
+        final String code = generator.generateCode(element.samples.first);
+        expect(code, contains('// Description'));
+        expect(
+            code, contains(RegExp('^void ${element.name}Sample\\(\\) \\{.*\$', multiLine: true)));
+        final String html = generator.generateHtml(element.samples.first);
+        expect(html, contains(RegExp('''^<iframe class="snippet-dartpad" src="https://dartpad.dev/.*sample_id=${element.name}.0.*></iframe>.*\$''', multiLine: true)));
+      }
+      expect(sampleCount, equals(1));
+    });
+    test('parses dartpad samples from linked file', () async {
+      final File inputFile = _createDartpadSourceFile(tmpDir, memoryFileSystem, flutterRoot, linked: true);
+      final Iterable<SourceElement> elements = getFileElements(inputFile,
+          resourceProvider: FileSystemResourceProvider(memoryFileSystem));
+      expect(elements, isNotEmpty);
+      final SnippetDartdocParser sampleParser = SnippetDartdocParser(memoryFileSystem);
+      sampleParser.parseFromComments(elements);
+      expect(elements.length, equals(1));
+      int sampleCount = 0;
+      for (final SourceElement element in elements) {
+        expect(element.samples.length, greaterThanOrEqualTo(1));
+        sampleCount += element.samples.length;
+        final String code = generator.generateCode(element.samples.first, formatOutput: false);
+        expect(code, contains('// Description'));
+        expect(
+            code, contains(RegExp('^void ${element.name}Sample\\(\\) \\{.*\$', multiLine: true)));
+        final String html = generator.generateHtml(element.samples.first);
+        expect(html, contains(RegExp('''^<iframe class="snippet-dartpad" src="https://dartpad.dev/.*sample_id=${element.name}.0.*></iframe>.*\$''', multiLine: true)));
+      }
+      expect(sampleCount, equals(1));
+    });
     test('parses assumptions', () async {
-      final File inputFile = _createSourceFile(tmpDir, memoryFileSystem);
+      final File inputFile = _createSnippetSourceFile(tmpDir, memoryFileSystem);
       final SnippetDartdocParser sampleParser = SnippetDartdocParser(memoryFileSystem);
       final List<SourceLine> assumptions = sampleParser.parseAssumptions(inputFile);
       expect(assumptions.length, equals(1));
@@ -122,7 +165,7 @@ void main() {
   });
 }
 
-File _createSourceFile(Directory tmpDir, FileSystem filesystem) {
+File _createSnippetSourceFile(Directory tmpDir, FileSystem filesystem) {
   return filesystem.file(path.join(tmpDir.absolute.path, 'snippet_in.dart'))
     ..createSync(recursive: true)
     ..writeAsStringSync(r'''
@@ -140,8 +183,7 @@ import 'foo.dart';
 /// {@tool snippet}
 /// Description
 /// ```dart
-/// void topLevelVariableSample() {
-/// }
+/// String elementName = 'topLevelVariable';
 /// ```
 /// {@end-tool}
 int topLevelVariable = 4;
@@ -151,8 +193,7 @@ int topLevelVariable = 4;
 /// {@tool snippet}
 /// Description
 /// ```dart
-/// void topLevelFunctionSample() {
-/// }
+/// String elementName = 'topLevelFunction';
 /// ```
 /// {@end-tool}
 int topLevelFunction() {
@@ -164,16 +205,14 @@ int topLevelFunction() {
 /// {@tool snippet}
 /// Description
 /// ```dart
-/// void DocumentedClassSample() {
-/// }
+/// String elementName = 'DocumentedClass';
 /// ```
 /// {@end-tool}
 ///
 /// {@tool snippet}
 /// Description2
 /// ```dart
-/// void DocumentedClassSample2() {
-/// }
+/// String elementName = 'DocumentedClass';
 /// ```
 /// {@end-tool}
 class DocumentedClass {
@@ -181,8 +220,7 @@ class DocumentedClass {
   /// {@tool snippet}
   /// Description
   /// ```dart
-  /// void DocumentedClass.DocumentedClassSample() {
-  /// }
+  /// String elementName = 'DocumentedClass';
   /// ```
   /// {@end-tool}
   const DocumentedClass();
@@ -191,8 +229,7 @@ class DocumentedClass {
   /// {@tool snippet}
   /// Description
   /// ```dart
-  /// void DocumentedClass.DocumentedClass.nameSample() {
-  /// }
+  /// String elementName = 'DocumentedClass.name';
   /// ```
   /// {@end-tool}
   const DocumentedClass.name();
@@ -201,8 +238,7 @@ class DocumentedClass {
   /// {@tool snippet}
   /// Description
   /// ```dart
-  /// void intMemberSample() {
-  /// }
+  /// String elementName = 'DocumentedClass.intMember';
   /// ```
   /// {@end-tool}
   int intMember;  
@@ -211,11 +247,51 @@ class DocumentedClass {
   /// {@tool snippet}
   /// Description
   /// ```dart
-  /// void memberSample() {
-  /// }
+  /// String elementName = 'DocumentedClass.member';
   /// ```
   /// {@end-tool}
   void member() {}  
 }
+''');
+}
+
+File _createDartpadSourceFile(Directory tmpDir, FileSystem filesystem, Directory flutterRoot, {bool linked = false}) {
+  final File linkedFile = filesystem.file(path.join(flutterRoot.absolute.path, 'linked_file.dart'))..createSync(recursive: true)..writeAsStringSync('''
+// Copyright
+
+import 'foo.dart';
+
+// Description
+
+void DocumentedClassSample() {
+  String elementName = 'DocumentedClass';
+}
+''');
+
+  final String source = linked ?
+  '''
+/// ** See code in ${path.relative(linkedFile.path, from: flutterRoot.absolute.path)} **''' : '''
+/// ```dart
+/// void DocumentedClassSample() {
+///   String elementName = 'DocumentedClass';
+/// }
+/// ```''';
+
+  return filesystem.file(path.join(tmpDir.absolute.path, 'snippet_in.dart'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+// Copyright
+
+// @dart = 2.12
+
+import 'foo.dart';
+
+/// Class comment
+///
+/// {@tool dartpad --template=template}
+/// Description
+$source
+/// {@end-tool}
+class DocumentedClass {}
 ''');
 }

--- a/packages/snippets/test/snippet_parser_test.dart
+++ b/packages/snippets/test/snippet_parser_test.dart
@@ -256,7 +256,9 @@ class DocumentedClass {
 }
 
 File _createDartpadSourceFile(Directory tmpDir, FileSystem filesystem, Directory flutterRoot, {bool linked = false}) {
-  final File linkedFile = filesystem.file(path.join(flutterRoot.absolute.path, 'linked_file.dart'))..createSync(recursive: true)..writeAsStringSync('''
+  final File linkedFile = filesystem.file(path.join(flutterRoot.absolute.path, 'linked_file.dart'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
 // Copyright
 
 import 'foo.dart';

--- a/packages/snippets/test/snippets_test.dart
+++ b/packages/snippets/test/snippets_test.dart
@@ -89,7 +89,7 @@ void main() {
 ''');
       final File outputFile =
           memoryFileSystem.file(path.join(tmpDir.absolute.path, 'snippet_out.txt'));
-      final SnippetDartdocParser sampleParser = SnippetDartdocParser();
+      final SnippetDartdocParser sampleParser = SnippetDartdocParser(memoryFileSystem);
       const String sourcePath = 'packages/flutter/lib/src/widgets/foo.dart';
       const int sourceLine = 222;
       final SourceElement element = sampleParser.parseFromDartdocToolFile(
@@ -148,7 +148,7 @@ void main() {
 ```
 ''');
 
-      final SnippetDartdocParser sampleParser = SnippetDartdocParser();
+      final SnippetDartdocParser sampleParser = SnippetDartdocParser(memoryFileSystem);
       const String sourcePath = 'packages/flutter/lib/src/widgets/foo.dart';
       const int sourceLine = 222;
       final SourceElement element = sampleParser.parseFromDartdocToolFile(
@@ -192,7 +192,7 @@ void main() {
 ```
 ''');
 
-      final SnippetDartdocParser sampleParser = SnippetDartdocParser();
+      final SnippetDartdocParser sampleParser = SnippetDartdocParser(memoryFileSystem);
       const String sourcePath = 'packages/flutter/lib/src/widgets/foo.dart';
       const int sourceLine = 222;
       final SourceElement element = sampleParser.parseFromDartdocToolFile(
@@ -239,7 +239,7 @@ void main() {
       final File expectedMetadataFile =
           memoryFileSystem.file(path.join(tmpDir.absolute.path, 'snippet_out.json'));
 
-      final SnippetDartdocParser sampleParser = SnippetDartdocParser();
+      final SnippetDartdocParser sampleParser = SnippetDartdocParser(memoryFileSystem);
       const String sourcePath = 'packages/flutter/lib/src/widgets/foo.dart';
       const int sourceLine = 222;
       final SourceElement element = sampleParser.parseFromDartdocToolFile(

--- a/utils/sampler/lib/model.dart
+++ b/utils/sampler/lib/model.dart
@@ -22,7 +22,7 @@ class Model extends ChangeNotifier {
   })  : _workingFile = workingFile,
         flutterRoot = flutterRoot ?? _findFlutterRoot(),
         dartUiRoot = dartUiRoot ?? _findDartUiRoot(),
-        _dartdocParser = SnippetDartdocParser(),
+        _dartdocParser = SnippetDartdocParser(filesystem),
         _snippetGenerator = SnippetGenerator();
 
   static Model? _instance;


### PR DESCRIPTION
## Description

This modifies the sample parser to be able to understand samples that are "linked" by a reference in them, and read those samples off disk instead of trying to parse them from the sample itself.

This will enable the sample analyzer and dartdoc to be able to generate correct output.