### PR TITLE
Fix test CI script to run ALL the tests, instead of just the ones it likes.

### DIFF
--- a/ci/testing.sh
+++ b/ci/testing.sh
@@ -16,8 +16,26 @@ fi
 # Default to the first arg if SHARD isn't set, and to "test" if neither are set.
 SHARD="${SHARD:-${1:-test}}"
 
+function test_packages() {
+  for dir in "$REPO_DIR/packages/"* "$REPO_DIR/utils/"*; do
+    if [[ -e "$dir/pubspec.yaml" && -e "$dir/test" ]]; then
+      (cd "$dir" && flutter test)
+    fi
+  done
+}
+
+function test_publishable() {
+  for dir in "$REPO_DIR/packages/"* "$REPO_DIR/utils/"*; do
+    if [[ -e "$dir/CHANGELOG.md" ]]; then
+      (cd "$dir" && pub publish --dry-run)
+    fi
+  done
+}
+
 if [[ "$SHARD" == "test" ]]; then
   echo "Running tests."
   (cd "$REPO_DIR/bin" && pub run test)
-  (cd "$REPO_DIR/packages/diagram_capture" && flutter test)
+  test_packages
+  echo "Checking publishability."
+  test_publishable
 fi

--- a/packages/snippets/test/snippet_parser_test.dart
+++ b/packages/snippets/test/snippet_parser_test.dart
@@ -17,6 +17,11 @@ class FakeFlutterInformation extends FlutterInformation {
   final Directory flutterRoot;
 
   @override
+  Directory getFlutterRoot() {
+    return flutterRoot;
+  }
+
+  @override
   Map<String, dynamic> getFlutterInformation() {
     return <String, dynamic>{
       'flutterRoot': flutterRoot,

--- a/packages/snippets/test/snippets_test.dart
+++ b/packages/snippets/test/snippets_test.dart
@@ -320,14 +320,17 @@ void main() {
         ..writeAsString('/// Test file');
       snippets_main.main(<String>['--input=${input.absolute.path}', '--template=template']);
 
+      final Map<String, dynamic> metadata = mockSnippetGenerator.sample.metadata;
+      // Ignore the channel, because channel is really just the branch, and will be
+      // different on development workstations.
+      metadata.remove('channel');
       expect(
-          mockSnippetGenerator.sample.metadata,
+          metadata,
           equals(<String, dynamic>{
             'id': 'dart_ui.library.element',
             'element': 'element',
             'sourcePath': 'unknown.dart',
             'sourceLine': 1,
-            'channel': 'fix_ids',
             'serial': '',
             'package': 'dart:ui',
             'library': 'library',


### PR DESCRIPTION
## Description

The `testing.sh` CI script was a little deficient, and was only running a few of the tests, not all of them.

Now it will run any tests it sees, as well as testing the published packages for publishability.