### PR TITLE
Publish the 'extract_sample' command

### DIFF
--- a/packages/snippets/CHANGELOG.md
+++ b/packages/snippets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+* publish the extract_sample command.
+
 ## 0.2.3
 
 * Fix sample ID generation to not generate IDs with invalid characters in them (e.g. a ":" in "dart:ui").

--- a/packages/snippets/pubspec.yaml
+++ b/packages/snippets/pubspec.yaml
@@ -2,7 +2,7 @@ name: snippets
 description: A package for parsing and manipulating code samples in Flutter repo dartdoc comments.
 repository: https://github.com/flutter/assets-for-api-docs/tree/master/packages/snippets
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+snippets%22
-version: 0.2.3
+version: 0.2.4
 
 environment:
   sdk: ">=2.12.1 <3.0.0"
@@ -27,3 +27,4 @@ dev_dependencies:
 
 executables:
   snippets:
+  extract_sample:


### PR DESCRIPTION
## Description

Somehow the extract_sample command never got published in the pubspec.

This bumps the version, and publishes the command so that it can be run with `dart pub global run snippets:extract_sample`.

## Issues

- Addresses part of https://github.com/flutter/flutter/issues/89068