### PR TITLE
Rename some CI shards to be more in line with other repos

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ task:
     memory: 8G
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
-    - name: analyze
+    - name: analyze+format
       always:
         format_script: ./ci/tool_runner format --fail-on-change --clang-format=clang-format-12
         license_script: dart pub global run flutter_plugin_tools license-check
@@ -47,9 +47,9 @@ task:
       version_script: ./ci/tool_runner version-check
       publishable_script: ./ci/tool_runner publish-check
       depends_on:
-        - analyze
-    - name: tests-linux
+        - analyze+format
+    - name: tests
       script: ./ci/tool_runner test
       depends_on:
-        - analyze
+        - analyze+format
 

--- a/packages/diagram_capture/lib/diagram_capture.dart
+++ b/packages/diagram_capture/lib/diagram_capture.dart
@@ -552,6 +552,8 @@ class DiagramController {
         return 'NATIVE';
       case ui.ImageByteFormat.png:
         return 'PNG';
+      default:
+        throw ArgumentError('Unknown byte format $format');
     }
   }
 


### PR DESCRIPTION
## Description

- Renamed analyze to analyze+test
- Renamed tests-linux to tests

To be more in line with the packages and plugins repos.

## Related Issues

https://github.com/flutter/flutter/issues/88613