### PR TITLE
Clean up and make --template optional

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,4 +1,4 @@
-# Last updated 08/20/2021 (to rebuild the docker image, update this timestamp)
+# Last updated 10/01/2021 (to rebuild the docker image, update this timestamp)
 FROM cirrusci/flutter:dev
 
 RUN sudo apt-get update && \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-gcp_credentials: ENCRYPTED[!0e63b52bd7e4fda1cd7b7bf2b4fe515a27fadbeaced01f5ad8b699b81d3611ed64c5d3271bcd8426dd914ef41cba48a0!]
+gcp_credentials: ENCRYPTED[!48cff44dd32e9cc412d4d381c7fe68d373ca04cf2639f8192d21cb1a9ab5e21129651423a1cf88f3fd7fe2125c1cabd9!]
 
 env:
   CHANNEL: "master" # Default to master when not explicitly set by a task.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 gcp_credentials: ENCRYPTED[!48cff44dd32e9cc412d4d381c7fe68d373ca04cf2639f8192d21cb1a9ab5e21129651423a1cf88f3fd7fe2125c1cabd9!]
 
 env:
-  CHANNEL: "master" # Default to master when not explicitly set by a task.
+  CHANNEL: "dev" # Default to dev when not explicitly set by a task.
 
 tool_setup_template: &TOOL_SETUP_TEMPLATE
   tool_setup_script:
@@ -16,8 +16,11 @@ flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
     - cd $FLUTTER_HOME
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - git fetch origin
-    # Switch to the requested branch.
-    - git checkout $CHANNEL
+    # Fetch requested channel
+    - git fetch origin $CHANNEL
+    # Switch to the requested branch (and since dev is a local dir, use -- to
+    # force git to pick the branch)
+    - git checkout $CHANNEL --
     # Reset to upstream branch, rather than using pull, since the base image
     # can sometimes be in a state where it has diverged from upstream (!).
     - git reset --hard @{u}

--- a/.run/Extract.run.xml
+++ b/.run/Extract.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Extract" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
-    <option name="arguments" value="--input=&quot;$PROJECT_DIR$/../flutter/packages/flutter/lib/src/widgets/navigator.dart&quot;" />
+    <option name="arguments" value="--verbose --input=&quot;$PROJECT_DIR$/../flutter/packages/flutter/lib/src/widgets/scrollbar.dart&quot;" />
     <option name="envs">
       <entry key="FLUTTER_ROOT" value="$PROJECT_DIR$/../flutter" />
     </option>

--- a/ci/check
+++ b/ci/check
@@ -57,7 +57,7 @@ fi
 cd "$REPO_DIR"
 if [[ $ACTIVATE == 1 ]]; then
   echo "Activating plugin tools"
-  pub global activate flutter_plugin_tools
+  dart pub global activate flutter_plugin_tools
 fi
 
 for check in "${CHECKS[@]}"; do

--- a/ci/fix_format
+++ b/ci/fix_format
@@ -11,5 +11,5 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 cd "$REPO_DIR"
-pub global activate flutter_plugin_tools
-pub global run flutter_plugin_tools format "$@"
+dart pub global activate flutter_plugin_tools
+dart pub global run flutter_plugin_tools format "$@"

--- a/packages/diagram_capture/lib/diagram_capture.dart
+++ b/packages/diagram_capture/lib/diagram_capture.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:animation_metadata/animation_metadata.dart';

--- a/packages/diagrams/lib/src/alert_dialog.dart
+++ b/packages/diagrams/lib/src/alert_dialog.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/animation_status_value.dart
+++ b/packages/diagrams/lib/src/animation_status_value.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 import 'diagram_step.dart';

--- a/packages/diagrams/lib/src/curve.dart
+++ b/packages/diagrams/lib/src/curve.dart
@@ -8,7 +8,6 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:diagram_capture/diagram_capture.dart';
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 import 'diagram_step.dart';

--- a/packages/diagrams/lib/src/drawer.dart
+++ b/packages/diagrams/lib/src/drawer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/font_feature.dart
+++ b/packages/diagrams/lib/src/font_feature.dart
@@ -8,7 +8,6 @@ import 'dart:ui' show FontFeature;
 
 import 'package:diagram_capture/diagram_capture.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 
 import 'diagram_step.dart';
 

--- a/packages/diagrams/lib/src/gesture_detector.dart
+++ b/packages/diagrams/lib/src/gesture_detector.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/implicit_animations.dart
+++ b/packages/diagrams/lib/src/implicit_animations.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/ink_response_large.dart
+++ b/packages/diagrams/lib/src/ink_response_large.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/ink_response_small.dart
+++ b/packages/diagrams/lib/src/ink_response_small.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/ink_well.dart
+++ b/packages/diagrams/lib/src/ink_well.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/simple_dialog.dart
+++ b/packages/diagrams/lib/src/simple_dialog.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/sliver_app_bars.dart
+++ b/packages/diagrams/lib/src/sliver_app_bars.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 

--- a/packages/diagrams/lib/src/stroke_join.dart
+++ b/packages/diagrams/lib/src/stroke_join.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:diagram_capture/diagram_capture.dart';
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 import 'diagram_step.dart';

--- a/packages/diagrams/lib/src/tabs.dart
+++ b/packages/diagrams/lib/src/tabs.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/toggle_buttons.dart
+++ b/packages/diagrams/lib/src/toggle_buttons.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/transitions.dart
+++ b/packages/diagrams/lib/src/transitions.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';

--- a/packages/diagrams/lib/src/tween_sequence.dart
+++ b/packages/diagrams/lib/src/tween_sequence.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 import 'diagram_step.dart';

--- a/packages/diagrams/lib/src/tweens.dart
+++ b/packages/diagrams/lib/src/tweens.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:diagram_capture/diagram_capture.dart';
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 import 'diagram_step.dart';

--- a/packages/diagrams/lib/src/utils.dart
+++ b/packages/diagrams/lib/src/utils.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// This defines a colored placeholder with padding, used to represent a

--- a/packages/sampler/README.md
+++ b/packages/sampler/README.md
@@ -7,8 +7,8 @@ for the [API documentation](https://api.flutter.dev) for Flutter.
 The easiest way to run the app, is to do this:
 
 ```
-% pub global activate sampler  # Just need to do this the first time.
-% pub global run sampler
+% dart pub global activate sampler  # Just need to do this the first time.
+% dart pub global run sampler
 ```
 
 Which will build and run the app in release mode on your platform. The

--- a/packages/sampler/lib/detail_view.dart
+++ b/packages/sampler/lib/detail_view.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;

--- a/packages/sampler/lib/main.dart
+++ b/packages/sampler/lib/main.dart
@@ -7,11 +7,8 @@ import 'dart:io' as io;
 import 'package:args/args.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:path/path.dart' as path;
-import 'package:sampler/new_sample.dart';
 import 'package:sampler/sampler.dart';
 import 'package:snippets/snippets.dart';
 

--- a/packages/sampler/lib/new_sample.dart
+++ b/packages/sampler/lib/new_sample.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:snippets/snippets.dart';
 

--- a/packages/sampler/lib/utils.dart
+++ b/packages/sampler/lib/utils.dart
@@ -7,7 +7,6 @@ import 'dart:io' show ProcessResult;
 
 import 'package:file/file.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 import 'package:process_runner/process_runner.dart';

--- a/packages/snippets/CHANGELOG.md
+++ b/packages/snippets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5
+
+* Make the `--template` argument optional for dartpad and sample samples.
+
 ## 0.2.4
 
 * publish the extract_sample command.

--- a/packages/snippets/bin/extract_sample.dart
+++ b/packages/snippets/bin/extract_sample.dart
@@ -45,13 +45,13 @@ Future<void> main(List<String> argList) async {
     _kHelpOption,
     defaultsTo: false,
     negatable: false,
-    help: 'Prints help documentation for this command',
+    help: 'Prints help documentation for this command.',
   );
   parser.addFlag(
     _kVerboseOption,
     defaultsTo: false,
     negatable: false,
-    help: 'Prints extra output diagnostics',
+    help: 'Prints extra output diagnostics.',
   );
 
   final ArgResults args = parser.parse(argList);

--- a/packages/snippets/bin/extract_sample.dart
+++ b/packages/snippets/bin/extract_sample.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' show stderr, exit;
+import 'dart:io' show stderr, exit, exitCode;
 
 import 'package:args/args.dart';
 import 'package:file/file.dart';
@@ -21,6 +21,7 @@ const String _kCopyrightNotice = '''
 const String _kHelpOption = 'help';
 const String _kInputOption = 'input';
 const String _kOutputOption = 'output';
+const String _kVerboseOption = 'verbose';
 
 /// Extracts the samples from a source file to the given output directory, and
 /// removes them from the original source files, replacing them with a pointer
@@ -36,7 +37,7 @@ Future<void> main(List<String> argList) async {
   );
   parser.addOption(
     _kInputOption,
-    mandatory: true,
+    defaultsTo: null,
     help:
         'The input Flutter source file containing the sample code to extract.',
   );
@@ -46,12 +47,20 @@ Future<void> main(List<String> argList) async {
     negatable: false,
     help: 'Prints help documentation for this command',
   );
+  parser.addFlag(
+    _kVerboseOption,
+    defaultsTo: false,
+    negatable: false,
+    help: 'Prints extra output diagnostics',
+  );
 
   final ArgResults args = parser.parse(argList);
+  final bool verbose = (args[_kVerboseOption] as bool?) ?? false;
 
-  if (args[_kHelpOption] as bool) {
+  if ((args[_kHelpOption] as bool?) ?? false) {
     stderr.writeln(parser.usage);
-    exit(0);
+    exitCode = 1;
+    return;
   }
 
   if (args[_kInputOption] == null || (args[_kInputOption] as String).isEmpty) {
@@ -59,8 +68,8 @@ Future<void> main(List<String> argList) async {
     errorExit('The --$_kInputOption option must not be empty.');
   }
 
-  if (args[_kOutputOption] == null ||
-      (args[_kOutputOption] as String).isEmpty) {
+  final String outputPath = (args[_kOutputOption] as String?) ?? '';
+  if (outputPath.isEmpty) {
     stderr.writeln(parser.usage);
     errorExit('The --$_kOutputOption option must be specified, and not empty.');
   }
@@ -88,20 +97,21 @@ Future<void> main(List<String> argList) async {
     dartdocParser.parseFromComments(fileElements);
     dartdocParser.parseAndAddAssumptions(fileElements, input, silent: true);
 
+    if (verbose) {
+      print('Parsed ${fileElements.length} elements from ${input.path}');
+    }
     final String srcPath =
         path.relative(input.absolute.path, from: flutterSource);
-    final String dstPath = path.join(
-      flutterInformation.getFlutterRoot().absolute.path,
-      'examples',
-      'api',
-    );
     for (final SourceElement element
         in fileElements.where((SourceElement element) {
       return element.sampleCount > 0;
     })) {
+      if (verbose) {
+        print('Extracting ${element.sampleCount} samples from ${element.elementName}');
+      }
       for (final CodeSample sample in element.samples) {
         // Ignore anything else, because those are not full apps.
-        if (sample.type != 'dartpad' && sample.type != 'sample') {
+        if (sample.type != 'dartpad' && sample.type != 'sample' || sample.sourceFile != null) {
           continue;
         }
         snippetGenerator.generateCode(
@@ -112,7 +122,7 @@ Future<void> main(List<String> argList) async {
         );
         final File outputFile = filesystem.file(
           path.joinAll(<String>[
-            dstPath,
+            outputPath,
             'lib',
             path.withoutExtension(srcPath), // e.g. material/app_bar
             <String>[
@@ -130,13 +140,18 @@ Future<void> main(List<String> argList) async {
         final FlutterSampleLiberator liberator = FlutterSampleLiberator(
           element,
           sample,
-          location: filesystem.directory(dstPath),
+          location: filesystem.directory(outputPath),
         );
-        if (!filesystem.file(path.join(dstPath, 'pubspec.yaml')).existsSync()) {
-          print('Publishing ${outputFile.absolute.path}');
+        if (!filesystem.file(path.join(outputPath, 'pubspec.yaml')).existsSync()) {
+          if (verbose) {
+            print('Publishing ${outputFile.absolute.path}');
+          }
           await liberator.extract(
               overwrite: true, mainDart: outputFile, includeMobile: true);
         } else {
+          if (verbose) {
+            print('Writing ${outputFile.absolute.path}');
+          }
           await outputFile.absolute.writeAsString(sample.output);
         }
         await liberator.reinsertAsReference(outputFile);

--- a/packages/snippets/bin/extract_sample.dart
+++ b/packages/snippets/bin/extract_sample.dart
@@ -107,11 +107,13 @@ Future<void> main(List<String> argList) async {
       return element.sampleCount > 0;
     })) {
       if (verbose) {
-        print('Extracting ${element.sampleCount} samples from ${element.elementName}');
+        print(
+            'Extracting ${element.sampleCount} samples from ${element.elementName}');
       }
       for (final CodeSample sample in element.samples) {
         // Ignore anything else, because those are not full apps.
-        if (sample.type != 'dartpad' && sample.type != 'sample' || sample.sourceFile != null) {
+        if (sample.type != 'dartpad' && sample.type != 'sample' ||
+            sample.sourceFile != null) {
           continue;
         }
         snippetGenerator.generateCode(
@@ -142,7 +144,9 @@ Future<void> main(List<String> argList) async {
           sample,
           location: filesystem.directory(outputPath),
         );
-        if (!filesystem.file(path.join(outputPath, 'pubspec.yaml')).existsSync()) {
+        if (!filesystem
+            .file(path.join(outputPath, 'pubspec.yaml'))
+            .existsSync()) {
           if (verbose) {
             print('Publishing ${outputFile.absolute.path}');
           }

--- a/packages/snippets/bin/snippets.dart
+++ b/packages/snippets/bin/snippets.dart
@@ -206,21 +206,9 @@ void main(List<String> argList) {
     return;
   }
 
-  String? template;
+  String template = '';
   if (sampleType == 'sample' || sampleType == 'dartpad') {
-    const String errorMessage =
-        'The --$_kTemplateOption option must be specified for "sample" and "dartpad" sample types.';
-    if (args[_kTemplateOption] == null) {
-      errorExit(errorMessage);
-      return;
-    }
-    final String templateArg = args[_kTemplateOption]! as String;
-    if (templateArg.isEmpty) {
-      stderr.writeln(parser.usage);
-      errorExit(errorMessage);
-      return;
-    }
-    template = templateArg.replaceAll(RegExp(r'.tmpl$'), '');
+    template = (args[_kTemplateOption] as String? ?? '').replaceAll(RegExp(r'.tmpl$'), '');
   }
 
   final bool formatOutput = args[_kFormatOutputOption]! as bool;
@@ -276,7 +264,7 @@ void main(List<String> argList) {
     startLine: sourceLine,
     element: elementName,
     sourceFile: filesystem.file(sourcePath),
-    template: template ?? '',
+    template: template,
     type: sampleType,
   );
   final Map<String, Object?> metadata = <String, Object?>{

--- a/packages/snippets/bin/snippets.dart
+++ b/packages/snippets/bin/snippets.dart
@@ -208,7 +208,8 @@ void main(List<String> argList) {
 
   String template = '';
   if (sampleType == 'sample' || sampleType == 'dartpad') {
-    template = (args[_kTemplateOption] as String? ?? '').replaceAll(RegExp(r'.tmpl$'), '');
+    template = (args[_kTemplateOption] as String? ?? '')
+        .replaceAll(RegExp(r'.tmpl$'), '');
   }
 
   final bool formatOutput = args[_kFormatOutputOption]! as bool;

--- a/packages/snippets/lib/analysis.dart
+++ b/packages/snippets/lib/analysis.dart
@@ -309,6 +309,31 @@ class _SourceVisitor<T> extends RecursiveAstVisitor<T> {
   }
 
   @override
+  T? visitMixinDeclaration(MixinDeclaration node) {
+    enclosingClass = node.name.name;
+    if (!node.name.name.startsWith('_')) {
+      enclosingClass = node.name.name;
+      List<SourceLine> comment = <SourceLine>[];
+      if (node.documentationComment != null &&
+          node.documentationComment!.tokens.isNotEmpty) {
+        comment = _processComment(node.name.name, node.documentationComment!);
+      }
+      elements.add(
+        SourceElement(
+          SourceElementType.classType,
+          node.name.name,
+          node.beginToken.charOffset,
+          file: file,
+          comment: comment,
+        ),
+      );
+    }
+    final T? result = super.visitMixinDeclaration(node);
+    enclosingClass = '';
+    return result;
+  }
+
+  @override
   T? visitClassDeclaration(ClassDeclaration node) {
     enclosingClass = node.name.name;
     if (!node.name.name.startsWith('_')) {

--- a/packages/snippets/lib/analysis.dart
+++ b/packages/snippets/lib/analysis.dart
@@ -14,9 +14,6 @@ import 'package:analyzer/source/line_info.dart';
 import 'package:file/file.dart';
 import 'package:snippets/snippets.dart';
 
-import 'data_types.dart';
-import 'util.dart';
-
 /// Gets an iterable over all of the blocks of documentation comments in a file
 /// using the analyzer.
 ///

--- a/packages/snippets/lib/snippet_generator.dart
+++ b/packages/snippets/lib/snippet_generator.dart
@@ -358,9 +358,14 @@ class SnippetGenerator {
       case ApplicationSample:
         String app;
         if (sample.sourceFile == null) {
-          final Directory templatesDir = configuration.templatesDirectory;
           final String templateName = sample.template;
-          final File? templateFile =
+          if (templateName.isEmpty) {
+            io.stderr.writeln('Non-linked samples must have a --template argument.');
+            io.exit(1);
+          }
+          final Directory templatesDir = configuration.templatesDirectory;
+          File? templateFile;
+          templateFile =
               getTemplatePath(templateName, templatesDir: templatesDir);
           if (templateFile == null) {
             io.stderr.writeln(

--- a/packages/snippets/lib/snippet_generator.dart
+++ b/packages/snippets/lib/snippet_generator.dart
@@ -360,7 +360,8 @@ class SnippetGenerator {
         if (sample.sourceFile == null) {
           final String templateName = sample.template;
           if (templateName.isEmpty) {
-            io.stderr.writeln('Non-linked samples must have a --template argument.');
+            io.stderr
+                .writeln('Non-linked samples must have a --template argument.');
             io.exit(1);
           }
           final Directory templatesDir = configuration.templatesDirectory;

--- a/packages/snippets/lib/snippet_parser.dart
+++ b/packages/snippets/lib/snippet_parser.dart
@@ -203,7 +203,7 @@ class SnippetDartdocParser {
   /// assigns the resulting samples to the `samples` member of the given
   /// `element`.
   void parseComment(SourceElement element) {
-    // Whether or not we're in a snippet code sample (with template) specifically.
+    // Whether or not we're in a snippet code sample.
     bool inSnippet = false;
     // Whether or not we're in a '```dart' segment.
     bool inDart = false;

--- a/packages/snippets/pubspec.yaml
+++ b/packages/snippets/pubspec.yaml
@@ -2,7 +2,7 @@ name: snippets
 description: A package for parsing and manipulating code samples in Flutter repo dartdoc comments.
 repository: https://github.com/flutter/assets-for-api-docs/tree/master/packages/snippets
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+snippets%22
-version: 0.2.4
+version: 0.2.5
 
 environment:
   sdk: ">=2.12.1 <3.0.0"

--- a/packages/snippets/test/filesystem_resource_provider.dart
+++ b/packages/snippets/test/filesystem_resource_provider.dart
@@ -12,7 +12,6 @@ import 'package:file/file.dart' as file;
 import 'package:file/local.dart' as file;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart';
-import 'package:path/src/context.dart';
 import 'package:watcher/watcher.dart';
 
 /// The name of the directory containing plugin specific subfolders used to

--- a/packages/snippets/test/snippets_test.dart
+++ b/packages/snippets/test/snippets_test.dart
@@ -381,13 +381,6 @@ void main() {
               'The --input option must be specified, either on the command line, or in the INPUT environment variable.'));
       errorMessage = '';
 
-      snippets_main.main(<String>['--input=${input.absolute.path}']);
-      expect(
-          errorMessage,
-          equals(
-              'The --template option must be specified for "sample" and "dartpad" sample types.'));
-      errorMessage = '';
-
       snippets_main
           .main(<String>['--input=${input.absolute.path}', '--type=snippet']);
       expect(errorMessage, equals(''));


### PR DESCRIPTION
## Description

This makes the `--template` argument optional for the snippet tool, so that samples that have linked source files don't have to supply it, since it isn't needed.

Also, cleaned up some loose ends in the sample extractor, added support for parsing mixins (which was apparently missing), updated the GCP credentials for the CI, and fixed usages of `dart pub`.