### PR TITLE
Fix diagram generator and update README for issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ To create a new diagram:
 
 4. Run `bin/generate --name xxx` where 'xxx' is the name of your diagram.
 
+## Issues
+
+Please file any issues in the [main flutter repo](https://github.com/flutter/flutter/issues/new).
 
 ## Origin of third-party content
 

--- a/bin/generate
+++ b/bin/generate
@@ -6,5 +6,5 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 # Dart needs to be in the path already...
-(cd ${REPO_DIR}/bin; pub get)
+(cd ${REPO_DIR}/bin; dart pub get)
 dart --no-sound-null-safety "${REPO_DIR}/bin/generate.dart" "$@"

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -45,7 +45,7 @@ class DiagramGenerator {
   /// The path to the dart program to be run for generating the diagram.
   static final String generatorDir = path.join(
     projectDir,
-    'utils',
+    'packages',
     'diagram_generator',
   );
 


### PR DESCRIPTION
While trying to generate a diagram in a recent PR I noticed a couple of issues

fixes https://github.com/flutter/flutter/issues/96907

## Issues
### 1. Failed to locate the generator
The `generator.dart` fails as it points to non-existent `diagram_generator` directory inside `utils`. (utils directory doesn't exist in the project directory)

**It should point to `packages/diagram_generator`instead.**

<details> 
<summary>logs</summary> 
	
```console
tahatesser@Tahas-MacBook-Pro assets-for-api-docs % bin/generate -n material_app
Resolving dependencies... (1.3s)
  _fe_analyzer_shared 22.0.0 (34.0.0 available)
  analyzer 1.7.2 (3.2.0 available)
  coverage 1.0.3 (1.1.0 available)
  test 1.18.1 (1.20.1 available)
  test_api 0.4.5 (0.4.9 available)
  test_core 0.4.4 (0.4.11 available)
  vm_service 7.5.0 (8.1.0 available)
Got dependencies!
Dart path: lib/main.dart
Temp directory: /var/folders/nq/qrv10n_16352mql0kcw3fbd80000gn/T/api_generate_EnohKA
Creating images.
Running "flutter run -d macos --dart-entrypoint-args --name --dart-entrypoint-args material_app --dart-entrypoint-args --platform --dart-entrypoint-args macos --dart-entrypoint-args --output-dir --dart-entrypoint-args /var/folders/nq/qrv10n_16352mql0kcw3fbd80000gn/T/api_generate_EnohKA" in /Users/tahatesser/AndroidStudioProjects/assets-for-api-docs/utils/diagram_generator.
Unhandled exception:
ProcessRunnerException: Running "flutter run -d macos --dart-entrypoint-args --name --dart-entrypoint-args material_app --dart-entrypoint-args --platform --dart-entrypoint-args macos --dart-entrypoint-args --output-dir --dart-entrypoint-args /var/folders/nq/qrv10n_16352mql0kcw3fbd80000gn/T/api_generate_EnohKA" in /Users/tahatesser/AndroidStudioProjects/assets-for-api-docs/utils/diagram_generator failed with:
ProcessException: No such file or directory
  Command: /Users/tahatesser/Code/flutter/bin/flutter run -d macos --dart-entrypoint-args --name --dart-entrypoint-args material_app --dart-entrypoint-args --platform --dart-entrypoint-args macos --dart-entrypoint-args --output-dir --dart-entrypoint-args /var/folders/nq/qrv10n_16352mql0kcw3fbd80000gn/T/api_generate_EnohKA
#0      ProcessRunner.runProcess (package:process_runner/src/process_runner.dart:268:7)
<asynchronous suspension>
#1      DiagramGenerator._createScreenshots (file:///Users/tahatesser/AndroidStudioProjects/assets-for-api-docs/bin/generate.dart:180:5)
<asynchronous suspension>
#2      DiagramGenerator.generateDiagrams (file:///Users/tahatesser/AndroidStudioProjects/assets-for-api-docs/bin/generate.dart:109:7)
<asynchronous suspension>
#3      main (file:///Users/tahatesser/AndroidStudioProjects/assets-for-api-docs/bin/generate.dart:517:5)
<asynchronous suspension>
tahatesser@Tahas-MacBook-Pro assets-for-api-docs %
```
	
</details>

### 2. The generator is using the deprecated `pub get` command.
The generator should be using `dart pub get`(also having Dart in the path is one of the [prerequisites](https://github.com/flutter/assets-for-api-docs#prerequisites) in the [flutter/assets-for-api-docs/README](https://github.com/flutter/assets-for-api-docs#readme)) 

**As the standalone `pub` command is [deprecated](https://dart.dev/tools/pub/cmd).**


### 2. README doesn't include an issue tracker link
If there is an issue with this repo, README can point to the issue tracker.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
