### PR TITLE
Fix analyzer warnings

### DIFF
--- a/packages/diagrams/lib/src/image.dart
+++ b/packages/diagrams/lib/src/image.dart
@@ -40,7 +40,7 @@ class DiagramImage extends ImageProvider<DiagramImage>
   }
 
   @override
-  ImageStreamCompleter load(DiagramImage key, DecoderCallback decode) {
+  ImageStreamCompleter loadBuffer(DiagramImage key, DecoderBufferCallback decode) {
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(),
       chunkEvents: chunkEvents.stream,
@@ -105,7 +105,7 @@ class DiagramImage extends ImageProvider<DiagramImage>
   }
 
   @override
-  int get hashCode => hashValues(image, scale);
+  int get hashCode => Object.hash(image, scale);
 }
 
 class FrameBuilderImageDiagram extends ImageDiagram {

--- a/packages/diagrams/lib/src/image.dart
+++ b/packages/diagrams/lib/src/image.dart
@@ -40,7 +40,8 @@ class DiagramImage extends ImageProvider<DiagramImage>
   }
 
   @override
-  ImageStreamCompleter loadBuffer(DiagramImage key, DecoderBufferCallback decode) {
+  ImageStreamCompleter loadBuffer(
+      DiagramImage key, DecoderBufferCallback decode) {
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(),
       chunkEvents: chunkEvents.stream,

--- a/packages/snippets/pubspec.yaml
+++ b/packages/snippets/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
-  analyzer: ^4.0.0
+  analyzer: 4.3.1
   args: ^2.0.0
   dart_style: ^2.2.3
   file: ^6.1.0


### PR DESCRIPTION
Clean up some analyzer warnings and pin the `analyzer` to version 4.3.1 because newer versions a deprecating API we currently use heavily. They will require a larger migration for which I filed https://github.com/flutter/flutter/issues/109473.

https://github.com/flutter/flutter/issues/109469