### PR TITLE
Rename android application id

### DIFF
--- a/packages/diagram_generator/android/app/build.gradle
+++ b/packages/diagram_generator/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.example.diagram_generator"
+        applicationId "dev.flutter.diagram_generator"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         multiDexEnabled true

--- a/packages/diagram_generator/android/app/src/debug/AndroidManifest.xml
+++ b/packages/diagram_generator/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.diagram_generator">
+    package="dev.flutter.diagram_generator">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/packages/diagram_generator/android/app/src/main/AndroidManifest.xml
+++ b/packages/diagram_generator/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.diagram_generator">
+    package="dev.flutter.diagram_generator">
    <application
         android:label="diagram_generator"
         android:icon="@mipmap/ic_launcher">

--- a/packages/diagram_generator/android/app/src/main/kotlin/dev/flutter/diagram_generator/MainActivity.kt
+++ b/packages/diagram_generator/android/app/src/main/kotlin/dev/flutter/diagram_generator/MainActivity.kt
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package com.example.diagram_generator
+package dev.flutter.diagram_generator
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/packages/diagram_generator/android/app/src/profile/AndroidManifest.xml
+++ b/packages/diagram_generator/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.diagram_generator">
+    package="dev.flutter.diagram_generator">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->


### PR DESCRIPTION
This PR renames the android application id to make android work again.

Tested on windows / android where I was previously getting an adb error in the _transferImages step.