### PR TITLE
Update channel used by CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
     - git reset --hard @{u}
     # Run doctor to allow auditing of what version of Flutter the run is using.
     - flutter doctor -v
-  <<: *TOOL_SETUP_TEMPLATE
+  << : *TOOL_SETUP_TEMPLATE
 
 task:
   gke_container:
@@ -38,7 +38,7 @@ task:
     namespace: default
     cpu: 4
     memory: 8G
-  <<: *FLUTTER_UPGRADE_TEMPLATE
+  << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
     - name: analyze+format
       always:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 gcp_credentials: ENCRYPTED[!9c8e92e8da192ce2a51b7d4ed9948c4250d0bae3660193d9b901196c9692abbebe784d4a32e9f38b328571d65f6e7aed!]
 
 env:
-  CHANNEL: "master" # Default to dev when not explicitly set by a task.
+  CHANNEL: "master" # Default to master when not explicitly set by a task.
 
 tool_setup_template: &TOOL_SETUP_TEMPLATE
   tool_setup_script:
@@ -55,3 +55,4 @@ task:
       script: ./ci/tool_runner test
       depends_on:
         - analyze+format
+

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ tool_setup_template: &TOOL_SETUP_TEMPLATE
     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
     # Pinned version of the plugin tools, to avoid breakage in this repository
     # when pushing updates from flutter/plugins.
-    - dart pub global activate flutter_plugin_tools 0.5.0
+    - dart pub global activate flutter_plugin_tools 0.13.4+3
 
 flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
   upgrade_flutter_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 gcp_credentials: ENCRYPTED[!9c8e92e8da192ce2a51b7d4ed9948c4250d0bae3660193d9b901196c9692abbebe784d4a32e9f38b328571d65f6e7aed!]
 
 env:
-  CHANNEL: "dev" # Default to dev when not explicitly set by a task.
+  CHANNEL: "master" # Default to dev when not explicitly set by a task.
 
 tool_setup_template: &TOOL_SETUP_TEMPLATE
   tool_setup_script:
@@ -26,7 +26,7 @@ flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
     - git reset --hard @{u}
     # Run doctor to allow auditing of what version of Flutter the run is using.
     - flutter doctor -v
-  << : *TOOL_SETUP_TEMPLATE
+  <<: *TOOL_SETUP_TEMPLATE
 
 task:
   gke_container:
@@ -38,7 +38,7 @@ task:
     namespace: default
     cpu: 4
     memory: 8G
-  << : *FLUTTER_UPGRADE_TEMPLATE
+  <<: *FLUTTER_UPGRADE_TEMPLATE
   matrix:
     - name: analyze+format
       always:
@@ -55,4 +55,3 @@ task:
       script: ./ci/tool_runner test
       depends_on:
         - analyze+format
-

--- a/packages/diagram_capture/example/linux/main.cc
+++ b/packages/diagram_capture/example/linux/main.cc
@@ -4,7 +4,7 @@
 
 #include "my_application.h"
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }

--- a/packages/diagram_capture/example/linux/my_application.cc
+++ b/packages/diagram_capture/example/linux/my_application.cc
@@ -13,15 +13,15 @@
 
 struct _MyApplication {
   GtkApplication parent_instance;
-  char** dart_entrypoint_arguments;
+  char **dart_entrypoint_arguments;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 
 // Implements GApplication::activate.
-static void my_application_activate(GApplication* application) {
-  MyApplication* self = MY_APPLICATION(application);
-  GtkWindow* window =
+static void my_application_activate(GApplication *application) {
+  MyApplication *self = MY_APPLICATION(application);
+  GtkWindow *window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
   // Use a header bar when running in GNOME as this is the common style used
@@ -33,16 +33,16 @@ static void my_application_activate(GApplication* application) {
   // if future cases occur).
   gboolean use_header_bar = TRUE;
 #ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
+  GdkScreen *screen = gtk_window_get_screen(window);
   if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    const gchar *wm_name = gdk_x11_screen_get_window_manager_name(screen);
     if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
       use_header_bar = FALSE;
     }
   }
 #endif
   if (use_header_bar) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    GtkHeaderBar *header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
     gtk_header_bar_set_title(header_bar, "example");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
@@ -58,7 +58,7 @@ static void my_application_activate(GApplication* application) {
   fl_dart_project_set_dart_entrypoint_arguments(
       project, self->dart_entrypoint_arguments);
 
-  FlView* view = fl_view_new(project);
+  FlView *view = fl_view_new(project);
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
@@ -68,10 +68,10 @@ static void my_application_activate(GApplication* application) {
 }
 
 // Implements GApplication::local_command_line.
-static gboolean my_application_local_command_line(GApplication* application,
-                                                  gchar*** arguments,
-                                                  int* exit_status) {
-  MyApplication* self = MY_APPLICATION(application);
+static gboolean my_application_local_command_line(GApplication *application,
+                                                  gchar ***arguments,
+                                                  int *exit_status) {
+  MyApplication *self = MY_APPLICATION(application);
   // Strip out the first argument as it is the binary name.
   self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
 
@@ -89,22 +89,22 @@ static gboolean my_application_local_command_line(GApplication* application,
 }
 
 // Implements GObject::dispose.
-static void my_application_dispose(GObject* object) {
-  MyApplication* self = MY_APPLICATION(object);
+static void my_application_dispose(GObject *object) {
+  MyApplication *self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 
-static void my_application_class_init(MyApplicationClass* klass) {
+static void my_application_class_init(MyApplicationClass *klass) {
   G_APPLICATION_CLASS(klass)->activate = my_application_activate;
   G_APPLICATION_CLASS(klass)->local_command_line =
       my_application_local_command_line;
   G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
 }
 
-static void my_application_init(MyApplication* self) {}
+static void my_application_init(MyApplication *self) {}
 
-MyApplication* my_application_new() {
+MyApplication *my_application_new() {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID, "flags",
                                      G_APPLICATION_NON_UNIQUE, nullptr));

--- a/packages/diagram_capture/example/linux/my_application.h
+++ b/packages/diagram_capture/example/linux/my_application.h
@@ -17,6 +17,6 @@ G_DECLARE_FINAL_TYPE(MyApplication, my_application, MY, APPLICATION,
  *
  * Returns: a new #MyApplication.
  */
-MyApplication* my_application_new();
+MyApplication *my_application_new();
 
-#endif  // FLUTTER_MY_APPLICATION_H_
+#endif // FLUTTER_MY_APPLICATION_H_

--- a/packages/diagram_capture/lib/diagram_capture.dart
+++ b/packages/diagram_capture/lib/diagram_capture.dart
@@ -598,6 +598,8 @@ class DiagramController {
         return 'PNG';
       case ui.ImageByteFormat.rawStraightRgba:
         return 'RAW STRAIGHT RGBA';
+      case ui.ImageByteFormat.rawExtendedRgba128:
+        return 'RAW EXTENDED RGBA 128';
     }
   }
 

--- a/packages/diagram_generator/linux/my_application.cc
+++ b/packages/diagram_generator/linux/my_application.cc
@@ -13,15 +13,15 @@
 
 struct _MyApplication {
   GtkApplication parent_instance;
-  char** dart_entrypoint_arguments;
+  char **dart_entrypoint_arguments;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 
 // Implements GApplication::activate.
-static void my_application_activate(GApplication* application) {
-  MyApplication* self = MY_APPLICATION(application);
-  GtkWindow* window =
+static void my_application_activate(GApplication *application) {
+  MyApplication *self = MY_APPLICATION(application);
+  GtkWindow *window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
   // Use a header bar when running in GNOME as this is the common style used
@@ -33,16 +33,16 @@ static void my_application_activate(GApplication* application) {
   // if future cases occur).
   gboolean use_header_bar = TRUE;
 #ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
+  GdkScreen *screen = gtk_window_get_screen(window);
   if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    const gchar *wm_name = gdk_x11_screen_get_window_manager_name(screen);
     if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
       use_header_bar = FALSE;
     }
   }
 #endif
   if (use_header_bar) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    GtkHeaderBar *header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
     gtk_header_bar_set_title(header_bar, "diagram_generator");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
@@ -58,7 +58,7 @@ static void my_application_activate(GApplication* application) {
   fl_dart_project_set_dart_entrypoint_arguments(
       project, self->dart_entrypoint_arguments);
 
-  FlView* view = fl_view_new(project);
+  FlView *view = fl_view_new(project);
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
@@ -68,10 +68,10 @@ static void my_application_activate(GApplication* application) {
 }
 
 // Implements GApplication::local_command_line.
-static gboolean my_application_local_command_line(GApplication* application,
-                                                  gchar*** arguments,
-                                                  int* exit_status) {
-  MyApplication* self = MY_APPLICATION(application);
+static gboolean my_application_local_command_line(GApplication *application,
+                                                  gchar ***arguments,
+                                                  int *exit_status) {
+  MyApplication *self = MY_APPLICATION(application);
   // Strip out the first argument as it is the binary name.
   self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
 
@@ -89,22 +89,22 @@ static gboolean my_application_local_command_line(GApplication* application,
 }
 
 // Implements GObject::dispose.
-static void my_application_dispose(GObject* object) {
-  MyApplication* self = MY_APPLICATION(object);
+static void my_application_dispose(GObject *object) {
+  MyApplication *self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 
-static void my_application_class_init(MyApplicationClass* klass) {
+static void my_application_class_init(MyApplicationClass *klass) {
   G_APPLICATION_CLASS(klass)->activate = my_application_activate;
   G_APPLICATION_CLASS(klass)->local_command_line =
       my_application_local_command_line;
   G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
 }
 
-static void my_application_init(MyApplication* self) {}
+static void my_application_init(MyApplication *self) {}
 
-MyApplication* my_application_new() {
+MyApplication *my_application_new() {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID, "flags",
                                      G_APPLICATION_NON_UNIQUE, nullptr));

--- a/packages/diagram_viewer/android/app/src/main/kotlin/com/example/diagram_viewer/MainActivity.kt
+++ b/packages/diagram_viewer/android/app/src/main/kotlin/com/example/diagram_viewer/MainActivity.kt
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package com.example.diagram_viewer
 
 import io.flutter.embedding.android.FlutterActivity

--- a/packages/diagram_viewer/linux/main.cc
+++ b/packages/diagram_viewer/linux/main.cc
@@ -4,7 +4,7 @@
 
 #include "my_application.h"
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }

--- a/packages/diagram_viewer/linux/my_application.cc
+++ b/packages/diagram_viewer/linux/my_application.cc
@@ -13,15 +13,15 @@
 
 struct _MyApplication {
   GtkApplication parent_instance;
-  char** dart_entrypoint_arguments;
+  char **dart_entrypoint_arguments;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 
 // Implements GApplication::activate.
-static void my_application_activate(GApplication* application) {
-  MyApplication* self = MY_APPLICATION(application);
-  GtkWindow* window =
+static void my_application_activate(GApplication *application) {
+  MyApplication *self = MY_APPLICATION(application);
+  GtkWindow *window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
   // Use a header bar when running in GNOME as this is the common style used
@@ -33,16 +33,16 @@ static void my_application_activate(GApplication* application) {
   // if future cases occur).
   gboolean use_header_bar = TRUE;
 #ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
+  GdkScreen *screen = gtk_window_get_screen(window);
   if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    const gchar *wm_name = gdk_x11_screen_get_window_manager_name(screen);
     if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
       use_header_bar = FALSE;
     }
   }
 #endif
   if (use_header_bar) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    GtkHeaderBar *header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
     gtk_header_bar_set_title(header_bar, "diagram_viewer");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
@@ -58,7 +58,7 @@ static void my_application_activate(GApplication* application) {
   fl_dart_project_set_dart_entrypoint_arguments(
       project, self->dart_entrypoint_arguments);
 
-  FlView* view = fl_view_new(project);
+  FlView *view = fl_view_new(project);
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
@@ -68,10 +68,10 @@ static void my_application_activate(GApplication* application) {
 }
 
 // Implements GApplication::local_command_line.
-static gboolean my_application_local_command_line(GApplication* application,
-                                                  gchar*** arguments,
-                                                  int* exit_status) {
-  MyApplication* self = MY_APPLICATION(application);
+static gboolean my_application_local_command_line(GApplication *application,
+                                                  gchar ***arguments,
+                                                  int *exit_status) {
+  MyApplication *self = MY_APPLICATION(application);
   // Strip out the first argument as it is the binary name.
   self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
 
@@ -89,22 +89,22 @@ static gboolean my_application_local_command_line(GApplication* application,
 }
 
 // Implements GObject::dispose.
-static void my_application_dispose(GObject* object) {
-  MyApplication* self = MY_APPLICATION(object);
+static void my_application_dispose(GObject *object) {
+  MyApplication *self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 
-static void my_application_class_init(MyApplicationClass* klass) {
+static void my_application_class_init(MyApplicationClass *klass) {
   G_APPLICATION_CLASS(klass)->activate = my_application_activate;
   G_APPLICATION_CLASS(klass)->local_command_line =
       my_application_local_command_line;
   G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
 }
 
-static void my_application_init(MyApplication* self) {}
+static void my_application_init(MyApplication *self) {}
 
-MyApplication* my_application_new() {
+MyApplication *my_application_new() {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID, "flags",
                                      G_APPLICATION_NON_UNIQUE, nullptr));

--- a/packages/diagram_viewer/linux/my_application.h
+++ b/packages/diagram_viewer/linux/my_application.h
@@ -17,6 +17,6 @@ G_DECLARE_FINAL_TYPE(MyApplication, my_application, MY, APPLICATION,
  *
  * Returns: a new #MyApplication.
  */
-MyApplication* my_application_new();
+MyApplication *my_application_new();
 
-#endif  // FLUTTER_MY_APPLICATION_H_
+#endif // FLUTTER_MY_APPLICATION_H_

--- a/packages/diagram_viewer/windows/runner/flutter_window.cpp
+++ b/packages/diagram_viewer/windows/runner/flutter_window.cpp
@@ -8,7 +8,7 @@
 
 #include "flutter/generated_plugin_registrant.h"
 
-FlutterWindow::FlutterWindow(const flutter::DartProject& project)
+FlutterWindow::FlutterWindow(const flutter::DartProject &project)
     : project_(project) {}
 
 FlutterWindow::~FlutterWindow() {}
@@ -56,9 +56,9 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
   }
 
   switch (message) {
-    case WM_FONTCHANGE:
-      flutter_controller_->engine()->ReloadSystemFonts();
-      break;
+  case WM_FONTCHANGE:
+    flutter_controller_->engine()->ReloadSystemFonts();
+    break;
   }
 
   return Win32Window::MessageHandler(hwnd, message, wparam, lparam);

--- a/packages/diagram_viewer/windows/runner/flutter_window.h
+++ b/packages/diagram_viewer/windows/runner/flutter_window.h
@@ -14,19 +14,19 @@
 
 // A window that does nothing but host a Flutter view.
 class FlutterWindow : public Win32Window {
- public:
+public:
   // Creates a new FlutterWindow hosting a Flutter view running |project|.
-  explicit FlutterWindow(const flutter::DartProject& project);
+  explicit FlutterWindow(const flutter::DartProject &project);
   virtual ~FlutterWindow();
 
- protected:
+protected:
   // Win32Window:
   bool OnCreate() override;
   void OnDestroy() override;
   LRESULT MessageHandler(HWND window, UINT const message, WPARAM const wparam,
                          LPARAM const lparam) noexcept override;
 
- private:
+private:
   // The project to run.
   flutter::DartProject project_;
 
@@ -34,4 +34,4 @@ class FlutterWindow : public Win32Window {
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
 };
 
-#endif  // RUNNER_FLUTTER_WINDOW_H_
+#endif // RUNNER_FLUTTER_WINDOW_H_

--- a/packages/diagram_viewer/windows/runner/utils.cpp
+++ b/packages/diagram_viewer/windows/runner/utils.cpp
@@ -13,7 +13,7 @@
 
 void CreateAndAttachConsole() {
   if (::AllocConsole()) {
-    FILE* unused;
+    FILE *unused;
     if (freopen_s(&unused, "CONOUT$", "w", stdout)) {
       _dup2(_fileno(stdout), 1);
     }
@@ -28,7 +28,7 @@ void CreateAndAttachConsole() {
 std::vector<std::string> GetCommandLineArguments() {
   // Convert the UTF-16 command line arguments to UTF-8 for the Engine to use.
   int argc;
-  wchar_t** argv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
+  wchar_t **argv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
   if (argv == nullptr) {
     return std::vector<std::string>();
   }
@@ -45,7 +45,7 @@ std::vector<std::string> GetCommandLineArguments() {
   return command_line_arguments;
 }
 
-std::string Utf8FromUtf16(const wchar_t* utf16_string) {
+std::string Utf8FromUtf16(const wchar_t *utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }

--- a/packages/diagram_viewer/windows/runner/utils.h
+++ b/packages/diagram_viewer/windows/runner/utils.h
@@ -14,10 +14,10 @@ void CreateAndAttachConsole();
 
 // Takes a null-terminated wchar_t* encoded in UTF-16 and returns a std::string
 // encoded in UTF-8. Returns an empty std::string on failure.
-std::string Utf8FromUtf16(const wchar_t* utf16_string);
+std::string Utf8FromUtf16(const wchar_t *utf16_string);
 
 // Gets the command line arguments passed in as a std::vector<std::string>,
 // encoded in UTF-8. Returns an empty std::vector<std::string> on failure.
 std::vector<std::string> GetCommandLineArguments();
 
-#endif  // RUNNER_UTILS_H_
+#endif // RUNNER_UTILS_H_

--- a/packages/diagram_viewer/windows/runner/win32_window.cpp
+++ b/packages/diagram_viewer/windows/runner/win32_window.cpp
@@ -31,7 +31,7 @@ void EnableFullDpiSupportIfAvailable(HWND hwnd) {
     return;
   }
   auto enable_non_client_dpi_scaling =
-      reinterpret_cast<EnableNonClientDpiScaling*>(
+      reinterpret_cast<EnableNonClientDpiScaling *>(
           GetProcAddress(user32_module, "EnableNonClientDpiScaling"));
   if (enable_non_client_dpi_scaling != nullptr) {
     enable_non_client_dpi_scaling(hwnd);
@@ -39,15 +39,15 @@ void EnableFullDpiSupportIfAvailable(HWND hwnd) {
   }
 }
 
-}  // namespace
+} // namespace
 
 // Manages the Win32Window's window class registration.
 class WindowClassRegistrar {
- public:
+public:
   ~WindowClassRegistrar() = default;
 
   // Returns the singleton registar instance.
-  static WindowClassRegistrar* GetInstance() {
+  static WindowClassRegistrar *GetInstance() {
     if (!instance_) {
       instance_ = new WindowClassRegistrar();
     }
@@ -56,23 +56,23 @@ class WindowClassRegistrar {
 
   // Returns the name of the window class, registering the class if it hasn't
   // previously been registered.
-  const wchar_t* GetWindowClass();
+  const wchar_t *GetWindowClass();
 
   // Unregisters the window class. Should only be called if there are no
   // instances of the window.
   void UnregisterWindowClass();
 
- private:
+private:
   WindowClassRegistrar() = default;
 
-  static WindowClassRegistrar* instance_;
+  static WindowClassRegistrar *instance_;
 
   bool class_registered_ = false;
 };
 
-WindowClassRegistrar* WindowClassRegistrar::instance_ = nullptr;
+WindowClassRegistrar *WindowClassRegistrar::instance_ = nullptr;
 
-const wchar_t* WindowClassRegistrar::GetWindowClass() {
+const wchar_t *WindowClassRegistrar::GetWindowClass() {
   if (!class_registered_) {
     WNDCLASS window_class{};
     window_class.hCursor = LoadCursor(nullptr, IDC_ARROW);
@@ -104,11 +104,11 @@ Win32Window::~Win32Window() {
   Destroy();
 }
 
-bool Win32Window::CreateAndShow(const std::wstring& title, const Point& origin,
-                                const Size& size) {
+bool Win32Window::CreateAndShow(const std::wstring &title, const Point &origin,
+                                const Size &size) {
   Destroy();
 
-  const wchar_t* window_class =
+  const wchar_t *window_class =
       WindowClassRegistrar::GetInstance()->GetWindowClass();
 
   const POINT target_point = {static_cast<LONG>(origin.x),
@@ -135,14 +135,14 @@ LRESULT CALLBACK Win32Window::WndProc(HWND const window, UINT const message,
                                       WPARAM const wparam,
                                       LPARAM const lparam) noexcept {
   if (message == WM_NCCREATE) {
-    auto window_struct = reinterpret_cast<CREATESTRUCT*>(lparam);
+    auto window_struct = reinterpret_cast<CREATESTRUCT *>(lparam);
     SetWindowLongPtr(window, GWLP_USERDATA,
                      reinterpret_cast<LONG_PTR>(window_struct->lpCreateParams));
 
-    auto that = static_cast<Win32Window*>(window_struct->lpCreateParams);
+    auto that = static_cast<Win32Window *>(window_struct->lpCreateParams);
     EnableFullDpiSupportIfAvailable(window);
     that->window_handle_ = window;
-  } else if (Win32Window* that = GetThisFromHandle(window)) {
+  } else if (Win32Window *that = GetThisFromHandle(window)) {
     return that->MessageHandler(window, message, wparam, lparam);
   }
 
@@ -153,39 +153,39 @@ LRESULT
 Win32Window::MessageHandler(HWND hwnd, UINT const message, WPARAM const wparam,
                             LPARAM const lparam) noexcept {
   switch (message) {
-    case WM_DESTROY:
-      window_handle_ = nullptr;
-      Destroy();
-      if (quit_on_close_) {
-        PostQuitMessage(0);
-      }
-      return 0;
-
-    case WM_DPICHANGED: {
-      auto newRectSize = reinterpret_cast<RECT*>(lparam);
-      LONG newWidth = newRectSize->right - newRectSize->left;
-      LONG newHeight = newRectSize->bottom - newRectSize->top;
-
-      SetWindowPos(hwnd, nullptr, newRectSize->left, newRectSize->top, newWidth,
-                   newHeight, SWP_NOZORDER | SWP_NOACTIVATE);
-
-      return 0;
+  case WM_DESTROY:
+    window_handle_ = nullptr;
+    Destroy();
+    if (quit_on_close_) {
+      PostQuitMessage(0);
     }
-    case WM_SIZE: {
-      RECT rect = GetClientArea();
-      if (child_content_ != nullptr) {
-        // Size and position the child window.
-        MoveWindow(child_content_, rect.left, rect.top, rect.right - rect.left,
-                   rect.bottom - rect.top, TRUE);
-      }
-      return 0;
-    }
+    return 0;
 
-    case WM_ACTIVATE:
-      if (child_content_ != nullptr) {
-        SetFocus(child_content_);
-      }
-      return 0;
+  case WM_DPICHANGED: {
+    auto newRectSize = reinterpret_cast<RECT *>(lparam);
+    LONG newWidth = newRectSize->right - newRectSize->left;
+    LONG newHeight = newRectSize->bottom - newRectSize->top;
+
+    SetWindowPos(hwnd, nullptr, newRectSize->left, newRectSize->top, newWidth,
+                 newHeight, SWP_NOZORDER | SWP_NOACTIVATE);
+
+    return 0;
+  }
+  case WM_SIZE: {
+    RECT rect = GetClientArea();
+    if (child_content_ != nullptr) {
+      // Size and position the child window.
+      MoveWindow(child_content_, rect.left, rect.top, rect.right - rect.left,
+                 rect.bottom - rect.top, TRUE);
+    }
+    return 0;
+  }
+
+  case WM_ACTIVATE:
+    if (child_content_ != nullptr) {
+      SetFocus(child_content_);
+    }
+    return 0;
   }
 
   return DefWindowProc(window_handle_, message, wparam, lparam);
@@ -203,8 +203,8 @@ void Win32Window::Destroy() {
   }
 }
 
-Win32Window* Win32Window::GetThisFromHandle(HWND const window) noexcept {
-  return reinterpret_cast<Win32Window*>(
+Win32Window *Win32Window::GetThisFromHandle(HWND const window) noexcept {
+  return reinterpret_cast<Win32Window *>(
       GetWindowLongPtr(window, GWLP_USERDATA));
 }
 

--- a/packages/diagram_viewer/windows/runner/win32_window.h
+++ b/packages/diagram_viewer/windows/runner/win32_window.h
@@ -15,7 +15,7 @@
 // inherited from by classes that wish to specialize with custom
 // rendering and input handling
 class Win32Window {
- public:
+public:
   struct Point {
     unsigned int x;
     unsigned int y;
@@ -38,8 +38,8 @@ class Win32Window {
   // consistent size to will treat the width height passed in to this function
   // as logical pixels and scale to appropriate for the default monitor. Returns
   // true if the window was created successfully.
-  bool CreateAndShow(const std::wstring& title, const Point& origin,
-                     const Size& size);
+  bool CreateAndShow(const std::wstring &title, const Point &origin,
+                     const Size &size);
 
   // Release OS resources associated with window.
   void Destroy();
@@ -57,7 +57,7 @@ class Win32Window {
   // Return a RECT representing the bounds of the current client area.
   RECT GetClientArea();
 
- protected:
+protected:
   // Processes and route salient window messages for mouse handling,
   // size change and DPI. Delegates handling of these to member overloads that
   // inheriting classes can handle.
@@ -72,7 +72,7 @@ class Win32Window {
   // Called when Destroy is called.
   virtual void OnDestroy();
 
- private:
+private:
   friend class WindowClassRegistrar;
 
   // OS callback called by message pump. Handles the WM_NCCREATE message which
@@ -85,7 +85,7 @@ class Win32Window {
                                   LPARAM const lparam) noexcept;
 
   // Retrieves a class instance pointer for |window|
-  static Win32Window* GetThisFromHandle(HWND const window) noexcept;
+  static Win32Window *GetThisFromHandle(HWND const window) noexcept;
 
   bool quit_on_close_ = false;
 
@@ -96,4 +96,4 @@ class Win32Window {
   HWND child_content_ = nullptr;
 };
 
-#endif  // RUNNER_WIN32_WINDOW_H_
+#endif // RUNNER_WIN32_WINDOW_H_


### PR DESCRIPTION
Flutter channel used by Cirrus CI is currently set to `dev`, which has been retired a while ago. That's why PRs that make use of new APIs (https://github.com/flutter/assets-for-api-docs/pull/211, https://github.com/flutter/assets-for-api-docs/pull/207) fail the checks.
This PR changes channel to `master` to ensure that CI is always up to date with API changes.