### PR TITLE
Cleanup output locations to match updated dartdoc creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 .vscode/
 
 # Flutter/Dart/Pub related
-**/doc/api/
 .dart_tool/
 .flutter-plugins
 .packages

--- a/packages/diagram_capture/.gitignore
+++ b/packages/diagram_capture/.gitignore
@@ -21,7 +21,6 @@
 #.vscode/
 
 # Flutter/Dart/Pub related
-**/doc/api/
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/packages/diagram_capture/example/.gitignore
+++ b/packages/diagram_capture/example/.gitignore
@@ -21,7 +21,6 @@
 #.vscode/
 
 # Flutter/Dart/Pub related
-**/doc/api/
 **/ios/Flutter/.last_build_id
 .dart_tool/
 .flutter-plugins

--- a/packages/diagram_generator/.gitignore
+++ b/packages/diagram_generator/.gitignore
@@ -26,7 +26,6 @@
 .packages.generated
 
 # Flutter/Dart/Pub related
-**/doc/api/
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/packages/diagram_viewer/.gitignore
+++ b/packages/diagram_viewer/.gitignore
@@ -21,7 +21,6 @@
 #.vscode/
 
 # Flutter/Dart/Pub related
-**/doc/api/
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/packages/snippets/bin/snippets.dart
+++ b/packages/snippets/bin/snippets.dart
@@ -47,6 +47,9 @@ SnippetGenerator snippetGenerator = SnippetGenerator();
 /// parsing.
 Platform platform = const LocalPlatform();
 
+/// A singleton process manager that can be set by tests for use in testing
+ProcessManager processManager = const LocalProcessManager();
+
 /// Get the name of the channel these docs are from.
 ///
 /// First check env variable LUCI_BRANCH, then refer to the currently
@@ -61,10 +64,13 @@ String getChannelName({
   }
 
   final RegExp gitBranchRegexp = RegExp(r'^## (?<branch>.*)');
-  // Adding extra debugging output to help debug why git status inexplicably fails
-  // (random non-zero error code) about 2% of the time.
   final ProcessResult gitResult = processManager.runSync(
       <String>['git', 'status', '-b', '--porcelain'],
+      // Use the FLUTTER_ROOT, if defined.
+      workingDirectory: platform.environment['FLUTTER_ROOT']?.trim() ??
+          filesystem.currentDirectory.path,
+      // Adding extra debugging output to help debug why git status inexplicably fails
+      // (random non-zero error code) about 2% of the time.
       environment: <String, String>{'GIT_TRACE': '2', 'GIT_TRACE_SETUP': '2'});
   if (gitResult.exitCode != 0) {
     throw GitStatusFailed(gitResult);
@@ -85,12 +91,15 @@ const List<String> sampleTypes = <String>[
 
 // This is a hack to workaround the fact that git status inexplicably fails
 // (with random non-zero error code) about 2% of the time.
-String getChannelNameWithRetries() {
+String getChannelNameWithRetries({
+  Platform platform = const LocalPlatform(),
+  ProcessManager processManager = const LocalProcessManager(),
+}) {
   int retryCount = 0;
 
   while (retryCount < 2) {
     try {
-      return getChannelName();
+      return getChannelName(platform: platform, processManager: processManager);
     } on GitStatusFailed catch (e) {
       retryCount += 1;
       stderr.write(
@@ -98,7 +107,7 @@ String getChannelNameWithRetries() {
     }
   }
 
-  return getChannelName();
+  return getChannelName(platform: platform, processManager: processManager);
 }
 
 /// Generates snippet dartdoc output for a given input, and creates any sample
@@ -248,8 +257,9 @@ void main(List<String> argList) {
       return;
     }
     id = idParts.join('.');
-    output = filesystem.file(outputDirectory.childFile('$id.dart'));
+    output = outputDirectory.childFile('$id.dart');
   }
+  output.parent.createSync(recursive: true);
 
   final int? sourceLine = environment['SOURCE_LINE'] != null
       ? int.tryParse(environment['SOURCE_LINE']!)
@@ -265,7 +275,8 @@ void main(List<String> argList) {
     type: sampleType,
   );
   final Map<String, Object?> metadata = <String, Object?>{
-    'channel': getChannelNameWithRetries(),
+    'channel': getChannelNameWithRetries(
+        platform: platform, processManager: processManager),
     'serial': serial,
     'id': id,
     'package': packageName,

--- a/packages/snippets/bin/snippets.dart
+++ b/packages/snippets/bin/snippets.dart
@@ -47,7 +47,7 @@ SnippetGenerator snippetGenerator = SnippetGenerator();
 /// parsing.
 Platform platform = const LocalPlatform();
 
-/// A singleton process manager that can be set by tests for use in testing
+/// A singleton process manager that can be set by tests for use in testing.
 ProcessManager processManager = const LocalProcessManager();
 
 /// Get the name of the channel these docs are from.

--- a/packages/snippets/lib/src/configuration.dart
+++ b/packages/snippets/lib/src/configuration.dart
@@ -10,7 +10,6 @@ import 'package:path/path.dart' as path;
 class SnippetConfiguration {
   const SnippetConfiguration({
     required this.configDirectory,
-    required this.outputDirectory,
     required this.skeletonsDirectory,
     required this.templatesDirectory,
     this.filesystem = const LocalFileSystem(),
@@ -22,10 +21,6 @@ class SnippetConfiguration {
   /// the skeletons and templates.
   final Directory configDirectory;
 
-  /// This is where the snippets themselves will be written, in order to be
-  /// uploaded to the docs site.
-  final Directory outputDirectory;
-
   /// The directory containing the HTML skeletons to be filled out with metadata
   /// and returned to dartdoc for insertion in the output.
   final Directory skeletonsDirectory;
@@ -33,14 +28,6 @@ class SnippetConfiguration {
   /// The directory containing the code templates that can be referenced by the
   /// dartdoc.
   final Directory templatesDirectory;
-
-  /// This makes sure that the output directory exists, and creates it if it
-  /// doesn't.
-  void createOutputDirectoryIfNeeded() {
-    if (!outputDirectory.existsSync()) {
-      outputDirectory.createSync(recursive: true);
-    }
-  }
 
   /// Gets the skeleton file to use for the given [SampleType] and DartPad
   /// preference.
@@ -58,8 +45,6 @@ class FlutterRepoSnippetConfiguration extends SnippetConfiguration {
       : super(
           configDirectory: _underRoot(filesystem, flutterRoot,
               const <String>['dev', 'snippets', 'config']),
-          outputDirectory: _underRoot(filesystem, flutterRoot,
-              const <String>['dev', 'docs', 'doc', 'snippets']),
           skeletonsDirectory: _underRoot(filesystem, flutterRoot,
               const <String>['dev', 'snippets', 'config', 'skeletons']),
           templatesDirectory: _underRoot(

--- a/packages/snippets/lib/src/snippet_generator.dart
+++ b/packages/snippets/lib/src/snippet_generator.dart
@@ -43,11 +43,6 @@ class SnippetGenerator {
   static DartFormatter formatter =
       DartFormatter(pageWidth: 80, fixes: StyleFix.all);
 
-  /// This returns the output file for a given snippet ID. Only used for
-  /// [SampleType.sample] snippets.
-  File getOutputFile(String id) => configuration.filesystem
-      .file(path.join(configuration.outputDirectory.path, '$id.dart'));
-
   /// Gets the path to the template file requested.
   File? getTemplatePath(String templateName, {Directory? templatesDir}) {
     final Directory templateDir =
@@ -349,8 +344,6 @@ class SnippetGenerator {
     bool addSectionMarkers = false,
     bool includeAssumptions = false,
   }) {
-    configuration.createOutputDirectoryIfNeeded();
-
     sample.metadata['copyright'] ??= copyright;
     final List<TemplateInjection> snippetData = parseInput(sample);
     sample.description = description ?? sample.description;

--- a/packages/snippets/test/configuration_test.dart
+++ b/packages/snippets/test/configuration_test.dart
@@ -21,12 +21,6 @@ void main() {
       expect(config.configDirectory.path,
           matches(RegExp(r'[/\\]flutter sdk[/\\]dev[/\\]snippets[/\\]config')));
     });
-    test('output directory is correct', () async {
-      expect(
-          config.outputDirectory.path,
-          matches(RegExp(
-              r'[/\\]flutter sdk[/\\]dev[/\\]docs[/\\]doc[/\\]snippets')));
-    });
     test('skeleton directory is correct', () async {
       expect(
           config.skeletonsDirectory.path,

--- a/packages/snippets/test/snippet_parser_test.dart
+++ b/packages/snippets/test/snippet_parser_test.dart
@@ -71,7 +71,6 @@ void main() {
           .directory(path.join(tmpDir.absolute.path, 'flutter'));
       configuration = FlutterRepoSnippetConfiguration(
           flutterRoot: flutterRoot, filesystem: memoryFileSystem);
-      configuration.createOutputDirectoryIfNeeded();
       configuration.templatesDirectory.createSync(recursive: true);
       configuration.skeletonsDirectory.createSync(recursive: true);
       template = memoryFileSystem.file(

--- a/packages/snippets/test/snippets_test.dart
+++ b/packages/snippets/test/snippets_test.dart
@@ -74,7 +74,6 @@ void main() {
           flutterRoot: memoryFileSystem
               .directory(path.join(tmpDir.absolute.path, 'flutter')),
           filesystem: memoryFileSystem);
-      configuration.createOutputDirectoryIfNeeded();
       configuration.templatesDirectory.createSync(recursive: true);
       configuration.skeletonsDirectory.createSync(recursive: true);
       template = memoryFileSystem.file(
@@ -351,6 +350,7 @@ void main() {
 
       snippets_main.platform = platform;
       snippets_main.filesystem = memoryFileSystem;
+      snippets_main.processManager = fakeProcessManager;
       final File input = memoryFileSystem
           .file(tmpDir.childFile('input.snippet'))
         ..writeAsString('/// Test file');


### PR DESCRIPTION
## Description

In https://github.com/flutter/flutter/pull/132353 I added the ability to generate the API docs in a temporary folder instead of generating them into the flutter repo tree. This keeps the IDEs from trying to index thousands of HTML and JS files when the docs are generated, and keeps the API doc builds more hermetic.

To do that, though, I needed to make some changes to the snippets tool, since it was making assumptions about where its output would go.

## Tests
 - Updated tests for the snippets tool.