### PR TITLE
Backwards compatibility for master/main

### DIFF
--- a/packages/snippets/CHANGELOG.md
+++ b/packages/snippets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Backwards compatibility: Substitute in "main" when running on "master" channel.
+
 ## 0.4.2
 
 * Switch master channel to main.

--- a/packages/snippets/bin/snippets.dart
+++ b/packages/snippets/bin/snippets.dart
@@ -59,7 +59,11 @@ String getChannelName({
   ProcessManager processManager = const LocalProcessManager(),
 }) {
   final String? envReleaseChannel = platform.environment['LUCI_BRANCH']?.trim();
-  if (<String>['master', 'stable'].contains(envReleaseChannel)) {
+  if (<String>['master', 'stable', 'main'].contains(envReleaseChannel)) {
+    // Backward compatibility: Still support running on "master", but pretend it is "main".
+    if (envReleaseChannel == 'master') {
+      return 'main';
+    }
     return envReleaseChannel!;
   }
 

--- a/packages/snippets/pubspec.yaml
+++ b/packages/snippets/pubspec.yaml
@@ -2,7 +2,7 @@ name: snippets
 description: A package for parsing and manipulating code samples in Flutter repo dartdoc comments.
 repository: https://github.com/flutter/assets-for-api-docs/tree/main/packages/snippets
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+snippets%22
-version: 0.4.2
+version: 0.4.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
* Supports running on the `main` channel.
* Pretends that the `master` channel is the main channel.