### PR TITLE
Migrate radio_list_tile example to RadioGroup (removes deprecated usage)

### DIFF
--- a/packages/diagrams/lib/src/radio_list_tile.dart
+++ b/packages/diagrams/lib/src/radio_list_tile.dart
@@ -15,17 +15,14 @@ class LinkedLabelRadio extends StatelessWidget {
   const LinkedLabelRadio({
     required this.label,
     required this.padding,
-    required this.groupValue,
     required this.value,
-    required this.onChanged,
     super.key,
   });
 
   final String label;
   final EdgeInsets padding;
-  final bool groupValue;
   final bool value;
-  final ValueChanged<bool?> onChanged;
+  
 
   @override
   Widget build(BuildContext context) {
@@ -33,13 +30,7 @@ class LinkedLabelRadio extends StatelessWidget {
       padding: padding,
       child: Row(
         children: <Widget>[
-          Radio<bool>(
-            groupValue: groupValue,
-            value: value,
-            onChanged: (bool? newValue) {
-              onChanged(newValue);
-            },
-          ),
+          Radio<bool>(value: value),
           RichText(
             text: TextSpan(
               text: label,
@@ -63,37 +54,26 @@ class LabeledRadio extends StatelessWidget {
   const LabeledRadio({
     required this.label,
     required this.padding,
-    required this.groupValue,
     required this.value,
-    required this.onChanged,
     super.key,
   });
 
   final String label;
   final EdgeInsets padding;
-  final bool groupValue;
   final bool value;
-  final ValueChanged<bool?> onChanged;
+  
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
       onTap: () {
-        if (value != groupValue) {
-          onChanged(value);
-        }
+        RadioGroup.maybeOf<bool>(context)?.onChanged(value);
       },
       child: Padding(
         padding: padding,
         child: Row(
           children: <Widget>[
-            Radio<bool>(
-              groupValue: groupValue,
-              value: value,
-              onChanged: (bool? newValue) {
-                onChanged(newValue);
-              },
-            ),
+            Radio<bool>(value: value),
             Text(label),
           ],
         ),
@@ -127,29 +107,25 @@ class _RadioListTileDiagramState extends State<RadioListTileDiagram> {
             alignment: FractionalOffset.center,
             padding: const EdgeInsets.all(5.0),
             color: Colors.white,
-            child: Column(
-              children: <Widget>[
-                RadioListTile<SingingCharacter>(
-                  title: const Text('Lafayette'),
-                  value: SingingCharacter.lafayette,
-                  groupValue: _character,
-                  onChanged: (SingingCharacter? value) {
-                    setState(() {
-                      _character = value;
-                    });
-                  },
-                ),
-                RadioListTile<SingingCharacter>(
-                  title: const Text('Thomas Jefferson'),
-                  value: SingingCharacter.jefferson,
-                  groupValue: _character,
-                  onChanged: (SingingCharacter? value) {
-                    setState(() {
-                      _character = value;
-                    });
-                  },
-                ),
-              ],
+            child: RadioGroup<SingingCharacter>(
+              groupValue: _character,
+              onChanged: (SingingCharacter? value) {
+                setState(() {
+                  _character = value;
+                });
+              },
+              child: const Column(
+                children: <Widget>[
+                  RadioListTile<SingingCharacter>(
+                    title: Text('Lafayette'),
+                    value: SingingCharacter.lafayette,
+                  ),
+                  RadioListTile<SingingCharacter>(
+                    title: Text('Thomas Jefferson'),
+                    value: SingingCharacter.jefferson,
+                  ),
+                ],
+              ),
             ),
           ),
         );
@@ -161,31 +137,27 @@ class _RadioListTileDiagramState extends State<RadioListTileDiagram> {
             alignment: FractionalOffset.center,
             padding: const EdgeInsets.all(5.0),
             color: Colors.white,
-            child: Column(
-              children: <Widget>[
-                LinkedLabelRadio(
-                  label: 'First tappable label text',
-                  padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                  value: true,
-                  groupValue: _isRadioSelected,
-                  onChanged: (bool? newValue) {
-                    setState(() {
-                      _isRadioSelected = newValue!;
-                    });
-                  },
-                ),
-                LinkedLabelRadio(
-                  label: 'Second tappable label text',
-                  padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                  value: false,
-                  groupValue: _isRadioSelected,
-                  onChanged: (bool? newValue) {
-                    setState(() {
-                      _isRadioSelected = newValue!;
-                    });
-                  },
-                ),
-              ],
+            child: RadioGroup<bool>(
+              groupValue: _isRadioSelected,
+              onChanged: (bool? newValue) {
+                setState(() {
+                  _isRadioSelected = newValue!;
+                });
+              },
+              child: const Column(
+                children: <Widget>[
+                  LinkedLabelRadio(
+                    label: 'First tappable label text',
+                    padding: EdgeInsets.symmetric(horizontal: 5.0),
+                    value: true,
+                  ),
+                  LinkedLabelRadio(
+                    label: 'Second tappable label text',
+                    padding: EdgeInsets.symmetric(horizontal: 5.0),
+                    value: false,
+                  ),
+                ],
+              ),
             ),
           ),
         );
@@ -197,31 +169,27 @@ class _RadioListTileDiagramState extends State<RadioListTileDiagram> {
             alignment: FractionalOffset.center,
             padding: const EdgeInsets.all(5.0),
             color: Colors.white,
-            child: Column(
-              children: <Widget>[
-                LabeledRadio(
-                  label: 'This is the first label text',
-                  padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                  value: true,
-                  groupValue: _isRadioSelected,
-                  onChanged: (bool? newValue) {
-                    setState(() {
-                      _isRadioSelected = newValue!;
-                    });
-                  },
-                ),
-                LabeledRadio(
-                  label: 'This is the second label text',
-                  padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                  value: false,
-                  groupValue: _isRadioSelected,
-                  onChanged: (bool? newValue) {
-                    setState(() {
-                      _isRadioSelected = newValue!;
-                    });
-                  },
-                ),
-              ],
+            child: RadioGroup<bool>(
+              groupValue: _isRadioSelected,
+              onChanged: (bool? newValue) {
+                setState(() {
+                  _isRadioSelected = newValue!;
+                });
+              },
+              child: const Column(
+                children: <Widget>[
+                  LabeledRadio(
+                    label: 'This is the first label text',
+                    padding: EdgeInsets.symmetric(horizontal: 5.0),
+                    value: true,
+                  ),
+                  LabeledRadio(
+                    label: 'This is the second label text',
+                    padding: EdgeInsets.symmetric(horizontal: 5.0),
+                    value: false,
+                  ),
+                ],
+              ),
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- Migrate radio_list_tile diagrams to use RadioGroup
- Remove deprecated groupValue/onChanged on Radio/RadioListTile
- Update custom examples to use RadioGroup.maybeOf for onTap

## Details
- Wraps example columns with RadioGroup to manage selection state
- RadioListTile entries now specify only value/title as per new API
- LinkedLabelRadio and LabeledRadio updated:
  - LinkedLabelRadio: show radio + RichText without managing state
  - LabeledRadio: call RadioGroup.maybeOf<bool>(context)?.onChanged(value) on tap

This aligns with Flutter 3.32 radio API updates.

Fixes flutter/flutter#175355
