### PR TITLE
Add silent param to DiagramGenerator

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -28,13 +28,16 @@ class GeneratorException implements Exception {
 class DiagramGenerator {
   DiagramGenerator({
     this.device = '',
+    this.silent = false,
     ProcessRunner? processRunner,
     required this.temporaryDirectory,
     this.cleanup = true,
   }) : processRunner =
-           processRunner ?? ProcessRunner(printOutputDefault: true) {
-    print('Dart path: $generatorMain');
-    print('Temp directory: ${temporaryDirectory.path}');
+           processRunner ?? ProcessRunner(printOutputDefault: !silent) {
+    if (!silent) {
+      print('Dart path: $generatorMain');
+      print('Temp directory: ${temporaryDirectory.path}');
+    }
   }
 
   static const String flutterCommand = 'flutter';
@@ -79,6 +82,9 @@ class DiagramGenerator {
   /// Whether or not to cleanup the temporaryDirectory after generating diagrams.
   final bool cleanup;
 
+  /// Whether to suppress progress and child-process output.
+  final bool silent;
+
   /// The function used to run processes to completion.
   final ProcessRunner processRunner;
 
@@ -116,9 +122,11 @@ class DiagramGenerator {
         await temporaryDirectory.delete(recursive: true);
       }
     }
-    print(
-      'Elapsed time for diagram generation: ${DateTime.now().difference(startTime)}',
-    );
+    if (!silent) {
+      print(
+        'Elapsed time for diagram generation: ${DateTime.now().difference(startTime)}',
+      );
+    }
   }
 
   Future<void> _createScreenshots(
@@ -126,7 +134,9 @@ class DiagramGenerator {
     List<String> names,
     List<String> steps,
   ) async {
-    print('Creating images.');
+    if (!silent) {
+      print('Creating images.');
+    }
     final List<String> filters = <String>[];
     for (final String category in categories) {
       filters.add('--category');
@@ -215,7 +225,9 @@ class DiagramGenerator {
   Future<List<File>> _transferImages() async {
     final List<File> files = <File>[];
     if (deviceTargetPlatform.startsWith('android')) {
-      print('Collecting images from device.');
+      if (!silent) {
+        print('Collecting images from device.');
+      }
       final List<String> args = <String>[
         adbCommand,
         '-s',
@@ -294,9 +306,11 @@ class DiagramGenerator {
       if (!destination.parent.existsSync()) {
         destination.parent.createSync(recursive: true);
       }
-      print(
-        'Converting ${metadata.name} animation to ${metadata.videoFormat.name}.',
-      );
+      if (!silent) {
+        print(
+          'Converting ${metadata.name} animation to ${metadata.videoFormat.name}.',
+        );
+      }
       _generateCommands(
         metadata: metadata,
         destination: destination.path,
@@ -365,7 +379,7 @@ class DiagramGenerator {
             ],
             workingDirectory: temporaryDirectory,
             stdinRaw: _concatInputs(metadata.frameFiles),
-            printOutput: true,
+            printOutput: !silent,
           ),
         );
   }
@@ -394,7 +408,7 @@ class DiagramGenerator {
             ],
             workingDirectory: temporaryDirectory,
             stdinRaw: _concatInputs(metadata.frameFiles),
-            printOutput: true,
+            printOutput: !silent,
           ),
         );
     // Create the final gif with the palette.
@@ -413,7 +427,7 @@ class DiagramGenerator {
             ],
             workingDirectory: temporaryDirectory,
             stdinRaw: _concatInputs(metadata.frameFiles),
-            printOutput: true,
+            printOutput: !silent,
           ),
         );
   }
@@ -427,7 +441,9 @@ class DiagramGenerator {
       throw GeneratorException('Subprocess did not complete cleanly!');
     }
 
-    print('Processing ${inputFiles.length - 1} files...');
+    if (!silent) {
+      print('Processing ${inputFiles.length - 1} files...');
+    }
 
     final String errorsFileName = path.join(
       temporaryDirectory.absolute.path,
@@ -435,8 +451,10 @@ class DiagramGenerator {
     );
     final String errors = await File(errorsFileName).readAsString();
     if (errors.isNotEmpty) {
-      print('Failed. Errors:');
-      print(errors);
+      if (!silent) {
+        print('Failed. Errors:');
+        print(errors);
+      }
       throw GeneratorException('Failed with errors (see $errorsFileName).');
     }
 

--- a/bin/test/generate_test.dart
+++ b/bin/test/generate_test.dart
@@ -30,6 +30,7 @@ void main() {
         processRunner: ProcessRunner(processManager: processManager),
         temporaryDirectory: temporaryDirectory,
         cleanup: false,
+        silent: true,
       );
     });
 
@@ -37,73 +38,69 @@ void main() {
       temporaryDirectory.delete(recursive: true);
     });
 
-    try {
-      test('make sure generate generates', () async {
-        final Map<FakeInvocationRecord, List<ProcessResult>>
-        calls = <FakeInvocationRecord, List<ProcessResult>>{
-          FakeInvocationRecord(<String>[
-            'flutter',
-            'devices',
-            '--machine',
-          ], workingDirectory: temporaryDirectory.path): <ProcessResult>[
-            ProcessResult(
-              0,
-              0,
-              '[{"name": "linux", "id": "linux", "targetPlatform": "linux"}]',
-              '',
-            ),
-          ],
-          FakeInvocationRecord(
-            <String>[
+    test('make sure generate generates', () async {
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+            FakeInvocationRecord(<String>[
               'flutter',
-              'run',
-              '-d',
-              'linux',
-              '--dart-entrypoint-args',
-              '--platform',
-              '--dart-entrypoint-args',
-              'linux',
-              '--dart-entrypoint-args',
-              '--output-dir',
-              '--dart-entrypoint-args',
-              temporaryDirectory.path,
+              'devices',
+              '--machine',
+            ], workingDirectory: temporaryDirectory.path): <ProcessResult>[
+              ProcessResult(
+                0,
+                0,
+                '[{"name": "linux", "id": "linux", "targetPlatform": "linux"}]',
+                '',
+              ),
             ],
-            workingDirectory: path.join(
-              DiagramGenerator.projectDir,
-              'packages',
-              'diagram_generator',
-            ),
-          ): <ProcessResult>[
-            ProcessResult(0, 0, '', ''),
-          ],
-          FakeInvocationRecord(<String>[
-            'optipng',
-            '-zc1-9',
-            '-zm1-9',
-            '-zs0-3',
-            '-f0-5',
-            'output.png',
-            '-out',
-            path.join(DiagramGenerator.projectDir, 'assets', 'output.png'),
-          ], workingDirectory: temporaryDirectory.path): <ProcessResult>[
-            ProcessResult(0, 0, '', ''),
-          ],
-        };
-        processManager.fakeResults = calls;
-        // Fake an output file
-        final File errorLog = File(
-          path.join(temporaryDirectory.path, 'error.log'),
-        );
-        errorLog.writeAsString('');
-        final File output = File(
-          path.join(temporaryDirectory.path, 'output.png'),
-        );
-        output.writeAsString('');
-        await generator.generateDiagrams();
-        processManager.verifyCalls(calls.keys.toList());
-      });
-    } catch (e, s) {
-      print(s);
-    }
+            FakeInvocationRecord(
+              <String>[
+                'flutter',
+                'run',
+                '-d',
+                'linux',
+                '--dart-entrypoint-args',
+                '--platform',
+                '--dart-entrypoint-args',
+                'linux',
+                '--dart-entrypoint-args',
+                '--output-dir',
+                '--dart-entrypoint-args',
+                temporaryDirectory.path,
+              ],
+              workingDirectory: path.join(
+                DiagramGenerator.projectDir,
+                'packages',
+                'diagram_generator',
+              ),
+            ): <ProcessResult>[
+              ProcessResult(0, 0, '', ''),
+            ],
+            FakeInvocationRecord(<String>[
+              'optipng',
+              '-zc1-9',
+              '-zm1-9',
+              '-zs0-3',
+              '-f0-5',
+              'output.png',
+              '-out',
+              path.join(DiagramGenerator.projectDir, 'assets', 'output.png'),
+            ], workingDirectory: temporaryDirectory.path): <ProcessResult>[
+              ProcessResult(0, 0, '', ''),
+            ],
+          };
+      processManager.fakeResults = calls;
+      // Fake an output file
+      final File errorLog = File(
+        path.join(temporaryDirectory.path, 'error.log'),
+      );
+      errorLog.writeAsString('');
+      final File output = File(
+        path.join(temporaryDirectory.path, 'output.png'),
+      );
+      output.writeAsString('');
+      await generator.generateDiagrams();
+      processManager.verifyCalls(calls.keys.toList());
+    });
   });
 }

--- a/ci/test
+++ b/ci/test
@@ -10,3 +10,4 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 "$SCRIPT_DIR"/tool_runner test
 cd "$REPO_DIR"/bin
 dart test
+bash "$SCRIPT_DIR"/test_assets

--- a/ci/test_asset
+++ b/ci/test_asset
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+OUTPUT_FILE="$(mktemp)"
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+if ! "$REPO_DIR"/bin/generate >"$OUTPUT_FILE" 2>&1; then
+  cat "$OUTPUT_FILE"
+  exit 1
+fi
+
+if [[ -n "$(git -C "$REPO_DIR" status --porcelain -- assets)" ]]; then
+  echo 'Generated assets are out of date. Run bin/generate and commit the changes.'
+  git -C "$REPO_DIR" status --short -- assets
+  exit 1
+fi


### PR DESCRIPTION
Add silent param to DiagramGenerator and add a test to verify that generated assets are up to date.

Fixes https://github.com/flutter/flutter/issues/112116

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
